### PR TITLE
Materializes the submission model

### DIFF
--- a/app/authorizers/deployment_authorizer.rb
+++ b/app/authorizers/deployment_authorizer.rb
@@ -2,6 +2,8 @@
 
 class DeploymentAuthorizer < ApplicationAuthorizer
   def updatable_by?(reader, selection_params: nil)
+    return true if reader.has_role? :editor
+
     if selection_params
       return true if selection_params['context_id'] == resource.group.context_id
     end

--- a/app/authorizers/submission_authorizer.rb
+++ b/app/authorizers/submission_authorizer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SubmissionAuthorizer < ApplicationAuthorizer
+  def self.readable_by?(reader, deployment: nil)
+    if deployment
+      deployment.updatable_by? reader
+    else
+      true
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,4 +52,9 @@ class ApplicationController < ActionController::Base
   def authority_forbidden(_error)
     render file: Rails.root.join('public', '403.html'), status: 403, layout: false
   end
+
+  def download_as(filename, type = nil)
+    headers['Content-Disposition'] = "attachment; filename=\"#{filename}\""
+    headers['Content-Type'] ||= type
+  end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -14,7 +14,7 @@ class SubmissionsController < ApplicationController
     enrollment = current_reader.enrollment_for_case @quiz.case
     @deployment = enrollment.active_group.deployment_for_case(@quiz.case)
 
-    if Answer.create_all answers, quiz: @quiz, reader: current_reader
+    if Submission.create answers: answers, quiz: @quiz, reader: current_reader
       render partial: 'submission', status: :created
     else
       render status: :unprocessable_entity

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -5,9 +5,8 @@ class SubmissionsController < ApplicationController
   before_action :set_quiz
 
   def index
-    @answers = current_reader.answers
-                             .merge(@quiz.answers)
-                             .order(:created_at)
+    @submissions = Submission.where(quiz: @quiz)
+                             .merge(reader_accessible_submissions)
   end
 
   def create
@@ -22,6 +21,10 @@ class SubmissionsController < ApplicationController
   end
 
   private
+
+  def reader_accessible_submissions
+    Submission.where(reader: current_reader)
+  end
 
   def set_quiz
     @quiz = Quiz.find_by_id params['quiz_id']

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -56,8 +56,8 @@ class SubmissionsController < ApplicationController
     @quiz = @deployment.quiz
 
     Submission.includes(:reader, :answers)
-              .where(quiz_id: @quiz.id, reader_id: reader_ids)
-              .order(:created_at)
+              .where(quiz_id: @quiz.ancestors.pluck(:id),
+                     reader_id: reader_ids)
   end
 
   def answers

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,11 +2,27 @@
 
 class SubmissionsController < ApplicationController
   before_action :authenticate_reader!
-  before_action :set_quiz
+  before_action :set_quiz, only: %i[create]
 
+  # One reader’s submissions to fill the submitted post-test with their answers
+  # => /quizzes/:quiz_id/submissions
+  #
+  # All submissions from the readers in a particular deployment, for assessment
+  # => /deployments/:deployment_id/submissions
   def index
-    @submissions = Submission.where(quiz: @quiz)
-                             .merge(reader_accessible_submissions)
+    if set_quiz
+      @submissions = readers_submissions_for_quiz
+    elsif set_deployment
+      authorize_action_for Submission, deployment: @deployment
+      @submissions = all_submissions_for_deployment
+    else
+      head :not_found
+    end
+
+    respond_to do |format|
+      format.json
+      format.csv { download_as 'submissions.csv', 'text/csv' }
+    end
   end
 
   def create
@@ -22,12 +38,26 @@ class SubmissionsController < ApplicationController
 
   private
 
-  def reader_accessible_submissions
-    Submission.where(reader: current_reader)
-  end
-
   def set_quiz
     @quiz = Quiz.find_by_id params['quiz_id']
+  end
+
+  def set_deployment
+    @deployment = Deployment.includes(:quiz, group: [:readers])
+                            .find_by_id(params['deployment_id'])
+  end
+
+  def readers_submissions_for_quiz
+    Submission.includes(:answers).where(quiz: @quiz, reader: current_reader)
+  end
+
+  def all_submissions_for_deployment
+    reader_ids = @deployment.group.readers.pluck(:id)
+    @quiz = @deployment.quiz
+
+    Submission.includes(:reader, :answers)
+              .where(quiz_id: @quiz.id, reader_id: reader_ids)
+              .order(:created_at)
   end
 
   def answers

--- a/app/javascript/quiz/PostTest.jsx
+++ b/app/javascript/quiz/PostTest.jsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { values } from 'ramda'
 
-import { Button, Tooltip, Position, Intent } from '@blueprintjs/core'
+import { Button, Intent } from '@blueprintjs/core'
 
 import Sidebar from 'elements/Sidebar'
 import { providesQuiz } from './Quiz'
@@ -125,18 +125,12 @@ class PostTest extends React.Component<
                 onChange={(e: SyntheticInputEvent<*>) => onChange(q.id, e)}
               />
             ))}
-            <Tooltip
-              isDisabled={canSubmit}
-              content="Please answer all the questions"
-              position={Position.TOP}
-            >
-              <Button
-                disabled={!canSubmit}
-                intent={Intent.PRIMARY}
-                text="Submit"
-                onClick={this.handleSubmit}
-              />
-            </Tooltip>
+            <Button
+              disabled={!canSubmit}
+              intent={Intent.PRIMARY}
+              text="Submit"
+              onClick={this.handleSubmit}
+            />
           </div>
         </main>
       </div>

--- a/app/javascript/quiz/PreTest.jsx
+++ b/app/javascript/quiz/PreTest.jsx
@@ -6,7 +6,7 @@
 import React from 'react'
 
 import { Route } from 'react-router-dom'
-import { Dialog, Button, Tooltip, Position } from '@blueprintjs/core'
+import { Dialog, Button } from '@blueprintjs/core'
 import type { ContextRouter } from 'react-router-dom'
 
 import CaseOverview from 'overview/CaseOverview'
@@ -58,13 +58,7 @@ const PreTest = ({
 
         <div className="pt-dialog-footer">
           <div className="pt-dialog-footer-actions">
-            <Tooltip
-              isDisabled={canSubmit}
-              content="Please answer all the questions"
-              position={Position.TOP}
-            >
-              <Button disabled={!canSubmit} text="Submit" onClick={onSubmit} />
-            </Tooltip>
+            <Button disabled={!canSubmit} text="Submit" onClick={onSubmit} />
           </div>
         </div>
       </Dialog>

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -4,29 +4,13 @@ class Answer < ApplicationRecord
   belongs_to :question
   belongs_to :quiz
   belongs_to :reader
+  belongs_to :submission
 
   validates :content, presence: true
 
   scope :by_reader, ->(reader) { where reader: reader }
 
   before_save :cache_correctness
-
-  def self.create_all(answers, quiz:, reader:)
-    completion = reader.enrollment_for_case(quiz.case).case_completion
-    answer_params = { quiz: quiz, reader: reader, case_completion: completion }
-
-    all = []
-    begin
-      transaction do
-        answers.each do |answer|
-          all << Answer.create!(answer.merge(answer_params))
-        end
-      end
-    rescue ActiveRecord::RecordInvalid
-      return false
-    end
-    all
-  end
 
   private
 

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -30,9 +30,9 @@ class Quiz < ApplicationRecord
     end
   end
 
-  def questions
-    @questions ||= Question.where <<~SQL
-      questions.quiz_id IN (
+  def ancestors
+    @ancestors ||= Quiz.where <<~SQL
+      id IN (
         WITH RECURSIVE template_quizzes(id, template_id) AS (
             SELECT id, template_id
               FROM quizzes
@@ -46,6 +46,10 @@ class Quiz < ApplicationRecord
           FROM template_quizzes
       )
     SQL
+  end
+
+  def questions
+    @questions ||= Question.where quiz_id: ancestors.pluck(:id)
   end
 
   def answers

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -31,7 +31,7 @@ class Quiz < ApplicationRecord
   end
 
   def questions
-    Question.where <<~SQL
+    @questions ||= Question.where <<~SQL
       questions.quiz_id IN (
         WITH RECURSIVE template_quizzes(id, template_id) AS (
             SELECT id, template_id

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -5,6 +5,7 @@ class Quiz < ApplicationRecord
 
   has_many :deployments, dependent: :nullify
   has_many :custom_questions, class_name: 'Question', dependent: :destroy
+  has_many :submissions, dependent: :destroy
   belongs_to :case
   belongs_to :template, class_name: 'Quiz'
   belongs_to :author, class_name: 'Reader'

--- a/app/models/reader.rb
+++ b/app/models/reader.rb
@@ -19,6 +19,7 @@ class Reader < ApplicationRecord
   has_many :groups, through: :group_memberships
   has_many :deployments, through: :groups
 
+  has_many :submissions, dependent: :destroy
   has_many :answers, dependent: :destroy
   has_many :quizzes, through: :answers
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Submission < ApplicationRecord
+  include Authority::Abilities
+
   belongs_to :quiz
   belongs_to :reader
   has_many :answers, dependent: :destroy
@@ -20,5 +22,9 @@ class Submission < ApplicationRecord
     rescue ActiveRecord::RecordInvalid
       return false
     end
+  end
+
+  def answer(to_question_id:)
+    answers.find { |a| a.question_id == to_question_id }.content || ''
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -25,6 +25,6 @@ class Submission < ApplicationRecord
   end
 
   def answer(to_question_id:)
-    answers.find { |a| a.question_id == to_question_id }.content || ''
+    answers.find { |a| a.question_id == to_question_id }.try(:content) || ''
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Submission < ApplicationRecord
+  belongs_to :quiz
+  belongs_to :reader
+  has_many :answers, dependent: :destroy
+
+  def self.create(answers:, quiz:, reader:)
+    completion = reader.enrollment_for_case(quiz.case).case_completion
+    answer_params = { quiz: quiz, reader: reader, case_completion: completion }
+
+    begin
+      transaction do
+        submission = create! quiz: quiz, reader: reader
+        answers.each do |answer|
+          submission.answers.create! answer.merge(answer_params)
+        end
+        submission
+      end
+    rescue ActiveRecord::RecordInvalid
+      return false
+    end
+  end
+end

--- a/app/views/submissions/index.csv.erb
+++ b/app/views/submissions/index.csv.erb
@@ -1,0 +1,20 @@
+<%- headers = [
+                "Timestamp",
+                "Reader name",
+                "Reader email",
+                "Percent Completion"
+              ] + @quiz.questions.map(&:content) -%>
+<%= raw CSV.generate_line headers -%>
+<%= raw CSV.generate_line [
+                            '', 'Answer key', '', ''
+                          ] + @quiz.questions.map(&:correct_answer) -%>
+<%  @submissions.find_each do |submission| -%>
+<%    answers = @quiz.questions.map(&:id)
+                     .map {|id| submission.answer to_question_id: id} -%>
+<%=   raw CSV.generate_line [
+        submission.created_at,
+        submission.reader.name,
+        submission.reader.email,
+        submission.answers.take.case_completion,
+      ] + answers -%>
+<% end -%>

--- a/app/views/submissions/index.csv.erb
+++ b/app/views/submissions/index.csv.erb
@@ -2,7 +2,7 @@
                 "Timestamp",
                 "Reader name",
                 "Reader email",
-                "Percent Completion"
+                "Percent completion"
               ] + @quiz.questions.map(&:content) -%>
 <%= raw CSV.generate_line headers -%>
 <%= raw CSV.generate_line [

--- a/app/views/submissions/index.json.jbuilder
+++ b/app/views/submissions/index.json.jbuilder
@@ -2,11 +2,16 @@
 
 json.key_format! camelize: :lower
 
-json.set! :answers_by_question_id do
-  @answers.group_by(&:question_id).each do |question_id, answers|
-    json.set! question_id do
-      json.array! answers do |answer|
-        json.extract! answer, :id, :quiz_id, :content, :created_at, :correct
+json.set! :submissions do
+  @submissions.each do |submission|
+    json.set! submission.id do
+      json.extract! submission, :id, :reader_id, :quiz_id, :created_at
+      json.answers_by_question_id do
+        submission.answers.each do |answer|
+          json.set! answer.question_id do
+            json.extract! answer, :id, :question_id, :content, :created_at, :correct
+          end
+        end
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'csv'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,9 @@ Rails.application.routes.draw do
     end
 
     resources :groups, only: [] do
-      resources :deployments, shallow: true, only: %i[create edit update]
+      resources :deployments, shallow: true, only: %i[create edit update] do
+        resources :submissions, only: %i[index]
+      end
     end
 
     resources :enrollments, only: %i[index new create]

--- a/db/migrate/20171113192541_create_submissions.rb
+++ b/db/migrate/20171113192541_create_submissions.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class CreateSubmissions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :submissions do |t|
+      t.references :quiz, foreign_key: true
+      t.references :reader, foreign_key: true
+
+      t.timestamps
+    end
+
+    change_table :answers do |t|
+      t.references :submission, foreign_key: true
+    end
+
+    reversible do |dir|
+      dir.up do
+        submissions = ActiveRecord::Base.connection.execute <<~SQL
+          SELECT reader_id,
+                 quiz_id,
+                 min(created_at) AS created_at,
+                 array_agg(id) AS answer_ids
+            FROM answers
+           GROUP BY reader_id,
+                    quiz_id,
+                    case_completion,
+                    date_trunc('minute', created_at);
+        SQL
+
+        submissions.each do |s|
+          submission = Submission.create! reader_id: s['reader_id'],
+                                          quiz_id: s['quiz_id'],
+                                          created_at: s['created_at']
+
+          answer_ids = s['answer_ids'].gsub(/[^0-9,]/, '').split(',')
+          Answer.where(id: answer_ids).update_all(submission_id: submission.id)
+        end
+      end
+
+      dir.down {}
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -109,7 +109,8 @@ CREATE TABLE answers (
     correct boolean,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    case_completion numeric
+    case_completion numeric,
+    submission_id bigint
 );
 
 
@@ -974,6 +975,38 @@ CREATE TABLE schema_migrations (
 
 
 --
+-- Name: submissions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE submissions (
+    id bigint NOT NULL,
+    quiz_id bigint,
+    reader_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: submissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE submissions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: submissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE submissions_id_seq OWNED BY submissions.id;
+
+
+--
 -- Name: visits; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1200,6 +1233,13 @@ ALTER TABLE ONLY reply_notifications ALTER COLUMN id SET DEFAULT nextval('reply_
 --
 
 ALTER TABLE ONLY roles ALTER COLUMN id SET DEFAULT nextval('roles_id_seq'::regclass);
+
+
+--
+-- Name: submissions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY submissions ALTER COLUMN id SET DEFAULT nextval('submissions_id_seq'::regclass);
 
 
 --
@@ -1442,6 +1482,14 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
+-- Name: submissions submissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY submissions
+    ADD CONSTRAINT submissions_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: visits visits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1503,6 +1551,13 @@ CREATE INDEX index_answers_on_quiz_id ON answers USING btree (quiz_id);
 --
 
 CREATE INDEX index_answers_on_reader_id ON answers USING btree (reader_id);
+
+
+--
+-- Name: index_answers_on_submission_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_answers_on_submission_id ON answers USING btree (submission_id);
 
 
 --
@@ -1863,6 +1918,20 @@ CREATE INDEX index_roles_on_name_and_resource_type_and_resource_id ON roles USIN
 
 
 --
+-- Name: index_submissions_on_quiz_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_submissions_on_quiz_id ON submissions USING btree (quiz_id);
+
+
+--
+-- Name: index_submissions_on_reader_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_submissions_on_reader_id ON submissions USING btree (reader_id);
+
+
+--
 -- Name: index_visits_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1893,11 +1962,27 @@ ALTER TABLE ONLY comment_threads
 
 
 --
+-- Name: answers fk_rails_03d3a93cfc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY answers
+    ADD CONSTRAINT fk_rails_03d3a93cfc FOREIGN KEY (submission_id) REFERENCES submissions(id);
+
+
+--
 -- Name: enrollments fk_rails_0411d261ff; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY enrollments
     ADD CONSTRAINT fk_rails_0411d261ff FOREIGN KEY (case_id) REFERENCES cases(id);
+
+
+--
+-- Name: submissions fk_rails_369ed4eb5c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY submissions
+    ADD CONSTRAINT fk_rails_369ed4eb5c FOREIGN KEY (quiz_id) REFERENCES quizzes(id);
 
 
 --
@@ -2109,6 +2194,14 @@ ALTER TABLE ONLY podcasts
 
 
 --
+-- Name: submissions fk_rails_ea35513632; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY submissions
+    ADD CONSTRAINT fk_rails_ea35513632 FOREIGN KEY (reader_id) REFERENCES readers(id);
+
+
+--
 -- Name: deployments fk_rails_f49860c54d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2203,6 +2296,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171024180715'),
 ('20171025205053'),
 ('20171030185254'),
-('20171031161433');
+('20171031161433'),
+('20171113192541');
 
 


### PR DESCRIPTION
While previously we had relied on the abstraction of a submission resource for our API design, it wasn’t backed by a database model—any answers submitted at more-or-less the same time by the same person was implicitly a submission. In order to collate students’ answers, it’s just a good idea to have them explicitly grouped in submissions.