### PR TITLE
Add trackers to the case overview and the quizzes

### DIFF
--- a/app/javascript/overview/CaseOverview.jsx
+++ b/app/javascript/overview/CaseOverview.jsx
@@ -9,20 +9,39 @@ import { connect } from 'react-redux'
 import TableOfContents from './TableOfContents'
 import Billboard from './Billboard'
 import EnrollForm from './EnrollForm'
+import Tracker from 'utility/Tracker'
 
-import type { State } from 'redux/state'
+import type { ContextRouter } from 'react-router-dom'
+import type { State, Reader } from 'redux/state'
 
-const CaseOverview = ({ editing, signInForm, reader }) => {
+type StateProps = { editing: boolean, reader: ?Reader, signInForm: ?string }
+function mapStateToProps ({ caseData, edit }: State): StateProps {
+  return {
+    editing: edit.inProgress,
+    reader: caseData.reader,
+    signInForm: window.caseData.signInForm,
+  }
+}
+
+type Props = StateProps & ContextRouter
+const CaseOverview = ({ editing, location, reader, signInForm }: Props) => {
   return (
-    <div id="CaseOverview" className={`window ${editing && 'editing'}`}>
+    <div id="CaseOverview" className={`window ${editing ? 'editing' : ''}`}>
       <Billboard />
       <aside className="CaseOverviewRight">
+        {location.pathname === '/' && (
+          <Tracker
+            timerState="RUNNING"
+            targetKey={`overview`}
+            targetParameters={{ name: 'read_overview' }}
+          />
+        )}
         {signInForm != null ? (
           <div
             className="dialog"
             dangerouslySetInnerHTML={{ __html: signInForm }}
           />
-        ) : !reader.enrollment ? (
+        ) : reader && !reader.enrollment ? (
           <EnrollForm />
         ) : null}
         <TableOfContents />
@@ -31,11 +50,4 @@ const CaseOverview = ({ editing, signInForm, reader }) => {
   )
 }
 
-export default connect(
-  (state: State) => ({
-    reader: state.caseData.reader,
-    signInForm: (window.caseData.signInForm: ?string),
-    editing: state.edit.inProgress,
-  }),
-  () => {}
-)(CaseOverview)
+export default connect(mapStateToProps, () => {})(CaseOverview)

--- a/app/javascript/quiz/PreTest.jsx
+++ b/app/javascript/quiz/PreTest.jsx
@@ -12,6 +12,7 @@ import type { ContextRouter } from 'react-router-dom'
 import CaseOverview from 'overview/CaseOverview'
 import { providesQuiz } from './Quiz'
 import Question from './Question'
+import Tracker from 'utility/Tracker'
 
 import type { Question as QuestionT } from 'redux/state'
 import type { QuizProviderProps } from './Quiz'
@@ -20,10 +21,11 @@ type Props = ContextRouter & QuizProviderProps
 const PreTest = ({
   answers,
   canSubmit,
+  history,
+  id: quizId,
+  match,
   onChange,
   onSubmit,
-  history,
-  match,
   questions,
 }: Props) => {
   return (
@@ -61,6 +63,16 @@ const PreTest = ({
             <Button disabled={!canSubmit} text="Submit" onClick={onSubmit} />
           </div>
         </div>
+
+        <Tracker
+          timerState="RUNNING"
+          targetKey={`pre_test`}
+          targetParameters={{
+            name: 'read_quiz',
+            preOrPost: 'pre',
+            quizId,
+          }}
+        />
       </Dialog>
     </div>
   )

--- a/docs/trackable_event_schema.md
+++ b/docs/trackable_event_schema.md
@@ -2,12 +2,25 @@
 
 We are using [Ahoy](https://github.com/ankane/ahoy) to roll our own event analytics. We’re tracking
 
-- the reader’s time per card and time of engagement with our edgenotes and podcast, providing formative data with which we can improve our cases
-- which CaseElements the reader has engaged with, informing our analysis of pre/post test results and allowing us to identify students who skipped the case, going right to the evaluation
+* the reader’s time per card and time of engagement with our edgenotes and podcast, providing formative data with which we can improve our cases
+* which CaseElements the reader has engaged with, informing our analysis of pre/post test results and allowing us to identify students who skipped the case, going right to the evaluation
 
 For these purposes we collect events with metadata according to the following schema:
 
+### A reader visits the case overview
+
+```javascript
+{
+  name: 'read_overview',
+  properties: {
+    case_slug: string,
+    duration: number
+  }
+}
+```
+
 ### A reader reads a card
+
 ```javascript
 {
   name: 'read_card',
@@ -20,6 +33,7 @@ For these purposes we collect events with metadata according to the following sc
 ```
 
 ### A reader engages with an edgenote
+
 For video and audio edgenote, this counts time playing. For image edgenotes, this counts time zoomed in. For link edgenotes, the duration is meaningless; it counts one visit per event.
 
 ```javascript
@@ -34,6 +48,7 @@ For video and audio edgenote, this counts time playing. For image edgenotes, thi
 ```
 
 ### A reader listens to a podcast
+
 ```javascript
 {
   name: 'visit_podcast',
@@ -46,6 +61,7 @@ For video and audio edgenote, this counts time playing. For image edgenotes, thi
 ```
 
 ### A reader visits a CaseElement page
+
 ```javascript
 {
   name: 'visit_element',

--- a/docs/trackable_event_schema.md
+++ b/docs/trackable_event_schema.md
@@ -73,3 +73,19 @@ For video and audio edgenote, this counts time playing. For image edgenotes, thi
   },
 }
 ```
+
+### A reader reads a quiz
+
+_Note: the presence of this event does not mean the quiz was submitted._
+
+```javascript
+{
+  name: 'read_quiz',
+  properties: {
+    case_slug: string,
+    pre_or_post: 'pre' | 'post',
+    quiz_id: number,
+    duration: number
+  }
+}
+```


### PR DESCRIPTION
This PR adds a tracker to the case overview page, the pre-test interstitial, and the post-test page. The post-test tracker is only running before the reader submits her answers.

Closes #197 