### PR TITLE
Rework Edgenote creation workflow

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,42 @@
+version: "2"
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: false
+  identical-code:
+    enabled: false
+plugins:
+  rubocop:
+    enabled: true
+  eslint:
+    enabled: true
+exclude_patterns:
+  - "config/"
+  - "db/"
+  - "dist/"
+  - "features/"
+  - "**/node_modules/"
+  - "script/"
+  - "**/spec/"
+  - "**/test/"
+  - "**/tests/"
+  - "**/vendor/"
+  - "**/*_test.go"
+  - "**/*.d.ts"
+  - "flow-typed/"
+  - "bin/"

--- a/app/controllers/edgenotes_controller.rb
+++ b/app/controllers/edgenotes_controller.rb
@@ -10,11 +10,7 @@ class EdgenotesController < ApplicationController
 
   # @route [POST] `/cases/case-slug/edgenotes`
   def create
-    @edgenote = @case.edgenotes.build(
-      slug: params[:slug],
-      format: 'aside',
-      style: :v2
-    )
+    @edgenote = @case.edgenotes.build
 
     if @edgenote.save
       render partial: 'edgenote', locals: { edgenote: @edgenote }
@@ -42,7 +38,10 @@ class EdgenotesController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_edgenote
     @edgenote = Edgenote.where(slug: params[:slug])
-                        .includes(case: [:podcasts, :edgenotes, pages: [:cards], enrollments: [:reader]])
+                        .includes(case: [:podcasts,
+                                         :edgenotes,
+                                         pages: [:cards],
+                                         enrollments: [:reader]])
                         .first
   end
 
@@ -66,6 +65,8 @@ class EdgenotesController < ApplicationController
     headers['Access-Control-Allow-Origin'] = '*'
     headers['Access-Control-Allow-Methods'] = 'POST, PUT, DELETE, GET, OPTIONS'
     headers['Access-Control-Request-Method'] = '*'
-    headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, Authorization'
+    headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, ' \
+                                              'Content-Type, Accept, ' \
+                                              'Authorization'
   end
 end

--- a/app/javascript/card/CardContents.jsx
+++ b/app/javascript/card/CardContents.jsx
@@ -81,6 +81,7 @@ class CardContents extends React.Component<CardProps, *> {
       onChange,
       handleKeyCommand,
       handleDeleteCard,
+      getEdgenote,
       openedCitation,
       addCommentThread,
       theseCommentThreadsOpen,
@@ -118,7 +119,7 @@ class CardContents extends React.Component<CardProps, *> {
       >
         {theseCommentThreadsOpen ? <ScrollIntoView /> : null}
 
-        {editing && <EditorToolbar cardId={id} />}
+        {editing && <EditorToolbar cardId={id} getEdgenote={getEdgenote} />}
         {title}
         <FocusContainer
           active={!!(theseCommentThreadsOpen && acceptingSelection)}

--- a/app/javascript/card/index.jsx
+++ b/app/javascript/card/index.jsx
@@ -19,6 +19,7 @@ import {
 
 import { withRouter, matchPath } from 'react-router-dom'
 import { commentThreadsOpen, commentsOpen } from 'shared/routes'
+import withGetEdgenote from './withGetEdgenote'
 
 import type { ContextRouter } from 'react-router-dom'
 import type { DraftHandleValue } from 'draft-js/lib/DraftHandleValue'
@@ -131,6 +132,7 @@ export type CardProps = {|
   addCommentThread: () => Promise<any>,
   onChange: EditorState => void,
   handleKeyCommand: string => DraftHandleValue,
+  getEdgenote: () => Promise<string>,
 |}
 function mergeProps (
   stateProps: StateProps,
@@ -180,5 +182,7 @@ function mergeProps (
 
 export default withRouter(
   // $FlowFixMe
-  connect(mapStateToProps, mapDispatchToProps, mergeProps)(CardContents)
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)(
+    withGetEdgenote(CardContents)
+  )
 )

--- a/app/javascript/card/withGetEdgenote.jsx
+++ b/app/javascript/card/withGetEdgenote.jsx
@@ -1,0 +1,80 @@
+/**
+ * This Higher Order Component provides a function to get an Edgenote record for
+ * attachment to a Card. If all the case’s Edgenotes are attached to cards, this
+ * simply creates a new one; however if there are some Edgenotes that are not
+ * attached, it presents a library dialog letting the user select a previously
+ * created Edgenote or create a new one. I think this is sorta like redux-saga…
+ *
+ * @providesModule withGetEdgenote
+ * @flow
+ */
+
+import * as React from 'react'
+
+import EdgenoteLibrary from 'edgenotes/EdgenoteLibrary'
+
+type State = { open: boolean }
+
+export const GET_EDGENOTE_NO_PROMISE_ERROR =
+  'getEdgenote tried to resolve an invalid promise. What’s up?'
+
+function withGetEdgenote<Props: {}> (
+  Component: React.ComponentType<{ getEdgenote: () => Promise<string> } & Props>
+): React.ComponentType<Props> {
+  class WrapperComponent extends React.Component<Props, State> {
+    state = { open: false }
+
+    promise = new Promise(() => new Error(GET_EDGENOTE_NO_PROMISE_ERROR))
+    resolve: (slug: string) => void = _ => {}
+    reject: (error: mixed) => void = _ => {}
+
+    render () {
+      return (
+        <React.Fragment>
+          <Component {...this.props} getEdgenote={this.getEdgenote} />
+
+          {this.state.open && (
+            <EdgenoteLibrary
+              onSelectEdgenote={this.handleSelectEdgenote}
+              onCancel={this.handleCancel}
+            />
+          )}
+        </React.Fragment>
+      )
+    }
+
+    getEdgenote = () => {
+      if (!this.state.open) {
+        this.promise = new Promise((resolve, reject) => {
+          this.resolve = resolve
+          this.reject = reject
+          this.setState({ open: true })
+        })
+      }
+
+      return this.promise
+    }
+
+    handleSelectEdgenote = (slug: string) => {
+      this.resolve(slug)
+      this._reset()
+    }
+
+    handleCancel = () => {
+      this.reject()
+      this._reset()
+    }
+
+    _reset () {
+      this.setState({ open: false })
+      this.promise = new Promise(() => new Error(GET_EDGENOTE_NO_PROMISE_ERROR))
+      this.resolve = _ => {}
+      this.reject = _ => {}
+    }
+  }
+
+  WrapperComponent.displayName = `withGetEdgenote(${Component.displayName ||
+    Component.name})`
+  return WrapperComponent
+}
+export default withGetEdgenote

--- a/app/javascript/edgenotes/EdgenoteLibrary.jsx
+++ b/app/javascript/edgenotes/EdgenoteLibrary.jsx
@@ -90,12 +90,14 @@ class EdgenoteLibrary extends React.Component<Props> {
               create a brand new Edgenote and deal with these later."
             />
           </div>
+
           <Table>
             <tbody>
               {unattachedEdgenotes.map(edgenote => (
                 <UnattachedEdgenote
                   key={edgenote.slug}
                   edgenote={edgenote}
+                  intl={intl}
                   onSelect={() => onSelectEdgenote(edgenote.slug)}
                   onDelete={() => deleteEdgenote(edgenote.slug)}
                 />
@@ -151,7 +153,7 @@ const Td = styled.td`
  * Shows only the Edgenote attributes that would be visible based on that
  * Edgenote’s style.
  */
-const UnattachedEdgenote = ({ edgenote, onSelect, onDelete }) => {
+const UnattachedEdgenote = ({ edgenote, intl, onSelect, onDelete }) => {
   let attributeComponents = []
   if (edgenote.youtubeSlug) {
     attributeComponents = [YoutubeSlug, Blank, Blank]
@@ -167,20 +169,38 @@ const UnattachedEdgenote = ({ edgenote, onSelect, onDelete }) => {
     <tr>
       <td>
         <Button
+          aria-label={intl.formatMessage({
+            id: 'edgenotes.attach',
+            defaultMessage: 'Attach this Edgenote.',
+          })}
           className="pt-minimal pt-small"
           iconName="add"
           intent={Intent.SUCCESS}
           onClick={onSelect}
         />
       </td>
+
       <Td>
-        <Icon iconName="tag" /> {edgenote.caption || '—'}
+        <Icon
+          aria-label={intl.formatMessage({
+            id: 'edgenotes.caption',
+            defaultMessage: 'Caption: ',
+          })}
+          iconName="tag"
+        />{' '}
+        {edgenote.caption || '—'}
       </Td>
+
       {attributeComponents.map((Component, i) => (
-        <Component key={i} edgenote={edgenote} />
+        <Component key={i} edgenote={edgenote} intl={intl} />
       ))}
+
       <td>
         <Button
+          aria-label={intl.formatMessage({
+            id: 'edgenotes.delete',
+            defaultMessage: 'Delete this Edgenote.',
+          })}
           className="pt-minimal pt-small"
           iconName="trash"
           intent={Intent.DANGER}
@@ -195,23 +215,46 @@ const Link = styled.a.attrs({ target: '_blank', rel: 'noopener noreferrer' })``
 
 const Blank = () => <Td>—</Td>
 
-const YoutubeSlug = ({ edgenote }) => (
+const YoutubeSlug = ({ edgenote, intl }) => (
   <Td>
-    <Icon iconName="video" />
+    <Icon
+      aria-label={intl.formatMessage({
+        id: 'edgenotes.videoSlug',
+        defaultMessage: 'YouTube video slug:',
+      })}
+      iconName="video"
+    />
     <Link href={`https://www.youtube.com/watch?v=${edgenote.youtubeSlug}`}>
       {edgenote.youtubeSlug}
     </Link>
   </Td>
 )
 
-const PullQuote = ({ edgenote }) => (
+const PullQuote = ({ edgenote, intl }) => (
   <Td>
-    <Icon iconName="citation" /> {edgenote.pullQuote}
+    <Icon
+      aria-label={intl.formatMessage({
+        id: 'edgenotes.pullQuote',
+        defaultMessage: 'Quotation: ',
+      })}
+      iconName="citation"
+    />
+    {edgenote.pullQuote}
   </Td>
 )
 
-const HasAudio = ({ edgenote }) => (
-  <Td>{edgenote.audioUrl ? <Icon iconName="volume-up" /> : null}</Td>
+const HasAudio = ({ edgenote, intl }) => (
+  <Td>
+    {edgenote.audioUrl ? (
+      <Icon
+        aria-label={intl.formatMessage({
+          id: 'edgenotes.hasAudio',
+          defaultMessage: 'This edgenote has an audio clip.',
+        })}
+        iconName="volume-up"
+      />
+    ) : null}
+  </Td>
 )
 
 const Img = styled.img`

--- a/app/javascript/edgenotes/EdgenoteLibrary.jsx
+++ b/app/javascript/edgenotes/EdgenoteLibrary.jsx
@@ -17,7 +17,7 @@ import { forEachObjIndexed } from 'ramda'
 import { Button, Dialog, Icon, Intent } from '@blueprintjs/core'
 
 import { getEdgenoteSlugs } from 'edgenotes'
-import { createEdgenote } from 'redux/actions'
+import { createEdgenote, deleteEdgenote } from 'redux/actions'
 
 import type { IntlShape } from 'react-intl'
 import type { State, CardsState, EdgenotesState, Edgenote } from 'redux/state'
@@ -45,19 +45,16 @@ function mapStateToProps ({ cardsById, edgenotesBySlug }: State) {
 
 type Props = {
   createEdgenote: () => Promise<string>,
+  deleteEdgenote: string => mixed,
   intl: IntlShape,
   unattachedEdgenotes: Edgenote[],
   onSelectEdgenote: string => void,
-  onCancel: () => void
+  onCancel: () => void,
 }
 
 class EdgenoteLibrary extends React.Component<Props> {
   componentDidMount () {
-    const {
-      unattachedEdgenotes,
-      onSelectEdgenote,
-      createEdgenote,
-    } = this.props
+    const { unattachedEdgenotes, onSelectEdgenote, createEdgenote } = this.props
     if (unattachedEdgenotes.length === 0) {
       createEdgenote().then(onSelectEdgenote)
     }
@@ -66,6 +63,7 @@ class EdgenoteLibrary extends React.Component<Props> {
   render () {
     const {
       createEdgenote,
+      deleteEdgenote,
       intl,
       unattachedEdgenotes,
       onSelectEdgenote,
@@ -99,6 +97,7 @@ class EdgenoteLibrary extends React.Component<Props> {
                   key={edgenote.slug}
                   edgenote={edgenote}
                   onSelect={() => onSelectEdgenote(edgenote.slug)}
+                  onDelete={() => deleteEdgenote(edgenote.slug)}
                 />
               ))}
             </tbody>
@@ -129,7 +128,7 @@ class EdgenoteLibrary extends React.Component<Props> {
     )
   }
 }
-export default connect(mapStateToProps, { createEdgenote })(
+export default connect(mapStateToProps, { createEdgenote, deleteEdgenote })(
   injectIntl(EdgenoteLibrary)
 )
 
@@ -152,7 +151,7 @@ const Td = styled.td`
  * Shows only the Edgenote attributes that would be visible based on that
  * Edgenote’s style.
  */
-const UnattachedEdgenote = ({ edgenote, onSelect }) => {
+const UnattachedEdgenote = ({ edgenote, onSelect, onDelete }) => {
   let attributeComponents = []
   if (edgenote.youtubeSlug) {
     attributeComponents = [YoutubeSlug, Blank, Blank]
@@ -180,6 +179,14 @@ const UnattachedEdgenote = ({ edgenote, onSelect }) => {
       {attributeComponents.map((Component, i) => (
         <Component key={i} edgenote={edgenote} />
       ))}
+      <td>
+        <Button
+          className="pt-minimal pt-small"
+          iconName="trash"
+          intent={Intent.DANGER}
+          onClick={onDelete}
+        />
+      </td>
     </tr>
   )
 }

--- a/app/javascript/edgenotes/EdgenoteLibrary.jsx
+++ b/app/javascript/edgenotes/EdgenoteLibrary.jsx
@@ -1,0 +1,126 @@
+/**
+ * This shows a list of the unattached Edgenotes from which the editor can
+ * choose and a button that allows the creation of a new Edgenote. If there are
+ * no unattached Edgenotes on the given case, this component immediately
+ * posts the request to create a new Edgenote; the dialog never truly opens.
+ *
+ * @providesModule EdgenoteLibrary
+ * @flow
+ */
+
+import * as React from 'react'
+import { connect } from 'react-redux'
+import { injectIntl } from 'react-intl'
+import { forEachObjIndexed } from 'ramda'
+
+import { Button, Dialog, Intent } from '@blueprintjs/core'
+
+import { getEdgenoteSlugs } from 'edgenotes'
+import { createEdgenote } from 'redux/actions'
+
+import type { IntlShape } from 'react-intl'
+import type { State, CardsState, EdgenotesState, Edgenote } from 'redux/state'
+
+function findUnattachedEdgenotes (
+  cardsById: CardsState,
+  edgenotesBySlug: EdgenotesState
+) {
+  const slugs = new Set(Object.keys(edgenotesBySlug))
+  forEachObjIndexed(card => {
+    card.editorState &&
+      getEdgenoteSlugs(card.editorState).forEach(slug => slugs.delete(slug))
+  }, cardsById)
+  return [...slugs].map(slug => edgenotesBySlug[slug])
+}
+
+function mapStateToProps ({ cardsById, edgenotesBySlug }: State) {
+  const unattachedEdgenotes = findUnattachedEdgenotes(
+    cardsById,
+    edgenotesBySlug
+  )
+
+  return { unattachedEdgenotes }
+}
+
+type Props = {
+  createEdgenote: () => Promise<string>,
+  intl: IntlShape,
+  unattachedEdgenotes: Edgenote[],
+  onSelectEdgenote: string => void,
+  onCancel: () => void,
+}
+
+class EdgenoteLibrary extends React.Component<Props> {
+  componentDidMount () {
+    const { unattachedEdgenotes, onSelectEdgenote, createEdgenote } = this.props
+    if (unattachedEdgenotes.length === 0) {
+      createEdgenote().then(onSelectEdgenote)
+    }
+  }
+
+  render () {
+    const {
+      createEdgenote,
+      intl,
+      unattachedEdgenotes,
+      onSelectEdgenote,
+      onCancel,
+    } = this.props
+
+    if (unattachedEdgenotes.length === 0) return null
+
+    return (
+      <Dialog isOpen={true} title="Unused Edgenotes" onClose={onCancel}>
+        <div className="pt-dialog-body">
+          <table className="pt-table pt-condensed">
+            <thead>
+              <tr>
+                <td />
+                <td>Caption</td>
+              </tr>
+            </thead>
+            <tbody>
+              {unattachedEdgenotes.map(edgenote => (
+                <tr key={edgenote.slug}>
+                  <td>
+                    <Button
+                      className="pt-minimal"
+                      iconName="add"
+                      text="Add"
+                      onClick={() => onSelectEdgenote(edgenote.slug)}
+                    />
+                  </td>
+                  <td>{edgenote.caption || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="pt-dialog-footer">
+          <div className="pt-dialog-footer-actions">
+            <Button
+              text={intl.formatMessage({
+                id: 'cancel',
+                defaultMessage: 'Cancel',
+              })}
+              onClick={onCancel}
+            />
+            <Button
+              iconName="add"
+              intent={Intent.PRIMARY}
+              text={intl.formatMessage({
+                id: 'edgenotes.new',
+                defaultMessage: 'New Edgenote',
+              })}
+              onClick={() => createEdgenote().then(onSelectEdgenote)}
+            />
+          </div>
+        </div>
+      </Dialog>
+    )
+  }
+}
+export default connect(mapStateToProps, { createEdgenote })(
+  injectIntl(EdgenoteLibrary)
+)

--- a/app/javascript/edgenotes/Image.jsx
+++ b/app/javascript/edgenotes/Image.jsx
@@ -1,0 +1,102 @@
+/**
+ * Image-style Edgenotes present an image which can be zoomed in. The caption
+ * should provide the “so what?” that contextualizes an image. It is possible
+ * that the caption can be descriptive enough not to require alt text.
+ *
+ * @providesModule Image
+ * @flow
+ */
+
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { EditableText } from '@blueprintjs/core'
+import ImageZoom from 'react-medium-image-zoom'
+
+import EditableAttribute from 'utility/EditableAttribute'
+
+import type { ReduxProps } from './Edgenote'
+
+type Props = {
+  src: string,
+  alt: string,
+  photoCredit: string,
+  callToAction: string,
+  onChange: string => string => any,
+  ...ReduxProps,
+}
+
+const Image = ({
+  src,
+  alt,
+  photoCredit,
+  callToAction,
+  active,
+  activate,
+  deactivate,
+  editing,
+  onChange,
+}: Props) => {
+  let imageProps = {
+    style: { width: '100%', minHeight: '3em', display: 'block' },
+    src: `${src}?w=640`,
+    alt,
+  }
+  let imageComponent = callToAction ? (
+    <img alt={alt} {...imageProps} />
+  ) : (
+    <ImageZoom
+      isZoomed={active}
+      defaultStyles={{ overlay: { backgroundColor: '#1D2934' }}}
+      image={imageProps}
+      zoomImage={{ src }}
+      onZoom={activate}
+      onUnzoom={deactivate}
+    />
+  )
+
+  return (
+    <div>
+      {src &&
+        (editing || photoCredit) && (
+          <PhotoCredit>
+            <EditableText
+              multiline
+              value={photoCredit}
+              disabled={!editing}
+              placeholder={editing ? 'Photo credit' : ''}
+              onChange={onChange('photoCredit')}
+            />
+          </PhotoCredit>
+        )}
+      {src && imageComponent}
+      <EditableAttribute
+        disabled={!editing}
+        title="image url"
+        value={src}
+        onChange={onChange('imageUrl')}
+      />
+      {src && (
+        <EditableAttribute
+          disabled={!editing}
+          title="alt text"
+          value={alt}
+          onChange={onChange('altText')}
+        />
+      )}
+    </div>
+  )
+}
+
+export default Image
+
+const PhotoCredit = styled.cite`
+  text-transform: uppercase;
+  letter-spacing: 0.25px;
+  color: rgba(235, 234, 228, 0.5);
+  font: normal 500 10px 'tenso';
+  display: block;
+  min-width: 100%;
+  text-align: right;
+  margin: 2px -3px;
+`

--- a/app/javascript/edgenotes/PullQuote.jsx
+++ b/app/javascript/edgenotes/PullQuote.jsx
@@ -1,0 +1,157 @@
+/**
+ * A quotation-style Edgenote can have a pull quote, attribution for that
+ * quotation, and an audio snippet.
+ *
+ * If audio is provided, the pull quote is expected to provide a “hook” to
+ * compel a reader to listen. Otherwise, the quotation serves the same purpose
+ * for the website to which the Edgenote links.
+ *
+ * These pull quotes should be quite short: likely too short to stand alone
+ * without a website link or an audio snippet.
+ *
+ * @providesModule PullQuote
+ * @flow
+ */
+
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+
+import { EditableText } from '@blueprintjs/core'
+
+import EditableAttribute from 'utility/EditableAttribute'
+
+import type { ReduxProps } from './Edgenote'
+
+type Props = {
+  attribution: string,
+  audioUrl: string,
+  contents: string,
+  hasBackground: boolean,
+  onChangeProp: string => string => any,
+  ...ReduxProps,
+}
+const PullQuote = ({
+  attribution,
+  audioUrl,
+  contents,
+  hasBackground,
+  selected,
+  editing,
+  active,
+  onChangeProp,
+}: Props) => (
+  <React.Fragment>
+    <Background visible={hasBackground}>
+      {contents || editing ? (
+        <blockquote
+          className={selected ? 'edge--highlighted' : ''}
+          style={{
+            fontSize: '140%',
+            lineHeight: 1.3,
+            margin: '0 0 0.5em 0',
+            padding: '0',
+          }}
+        >
+          <EditableText
+            multiline
+            placeholder="“Add quotation...”"
+            value={contents}
+            disabled={!editing}
+            onChange={onChangeProp('pullQuote')}
+          />
+        </blockquote>
+      ) : null}
+      <Attribution
+        name={attribution}
+        editing={editing}
+        onChange={onChangeProp('attribution')}
+      />
+    </Background>
+    <AudioPlayer
+      src={audioUrl}
+      editing={editing}
+      active={active}
+      onChange={onChangeProp('audioUrl')}
+    />
+  </React.Fragment>
+)
+
+export default PullQuote
+
+const Background = styled.div`
+  ${p =>
+    p.visible &&
+    css`
+      background-color: #49647d;
+      padding: 0.5em 1em;
+      border-radius: 2px 2px 0 0;
+    `};
+`
+
+const Attribution = ({ name, editing, onChange }) =>
+  name || editing ? (
+    <cite
+      style={{
+        textAlign: 'right',
+        display: 'block',
+        fontStyle: 'normal',
+        margin: '0.5em 0 0.25em 0',
+        lineHeight: 1,
+      }}
+    >
+      <EditableText
+        multiline
+        placeholder="— Attribution"
+        value={name}
+        disabled={!editing}
+        onChange={onChange}
+      />
+    </cite>
+  ) : null
+
+type AudioPlayerProps = {
+  src: string,
+  active: boolean,
+  editing: boolean,
+  onChange: string => any,
+}
+
+class AudioPlayer extends React.Component<AudioPlayerProps> {
+  audioPlayer: ?HTMLAudioElement
+
+  componentDidUpdate (prevProps: AudioPlayerProps) {
+    if (!prevProps.active && this.props.active) {
+      this.audioPlayer && this.audioPlayer.play()
+    }
+  }
+
+  render () {
+    let { src, editing, onChange } = this.props
+    return (
+      <div>
+        {src && (
+          // TODO
+          // eslint-disable-next-line jsx-a11y/media-has-caption
+          <audio
+            controls
+            ref={c => {
+              this.audioPlayer = c
+            }}
+            style={{
+              width: '100%',
+              borderRadius: 2,
+              borderBottom: `4px solid #6ACB72`,
+            }}
+            src={src}
+          />
+        )}
+        <EditableAttribute
+          disabled={!editing}
+          title="audio url"
+          value={src}
+          onChange={onChange}
+        />
+      </div>
+    )
+  }
+}

--- a/app/javascript/edgenotes/YouTube.jsx
+++ b/app/javascript/edgenotes/YouTube.jsx
@@ -1,0 +1,51 @@
+/**
+ * Video-style Edgenotes currently only support YouTube. A caption should
+ * provide a “hook” which compels a reader to watch the video.
+ *
+ * @providesModule YouTube
+ * @flow
+ */
+
+import * as React from 'react'
+
+import YoutubePlayer from 'react-youtube-player'
+
+import EditableAttribute from 'utility/EditableAttribute'
+
+import type { ReduxProps } from './Edgenote'
+
+type Props = {
+  slug: string,
+  onChange: string => any,
+  ...ReduxProps,
+}
+const YouTube = ({
+  slug,
+  active,
+  activate,
+  deactivate,
+  editing,
+  onChange,
+}: Props) => (
+  <div>
+    {slug && (
+      <YoutubePlayer
+        videoId={slug}
+        playbackState={active ? 'playing' : 'paused'}
+        configuration={{
+          theme: 'light',
+        }}
+        onPlay={activate}
+        onPause={deactivate}
+      />
+    )}
+    <EditableAttribute
+      disabled={!editing}
+      title="YouTube slug"
+      value={slug}
+      onChange={onChange}
+    />
+  </div>
+)
+
+export default YouTube

--- a/app/javascript/edgenotes/index.jsx
+++ b/app/javascript/edgenotes/index.jsx
@@ -1,4 +1,11 @@
 /**
+ * This component extracts the edgenote slugs from a Card’s DraftEntities.
+ *
+ * Edgenotes exist in the old `v1` style, which looks too much like a textbook,
+ * and `v2` style that is clean and compelling. Multiple Edgenotes can be
+ * attached to one card, in which case they appear in order of their highlight
+ * strings in a grid maximum 2 Edgenotes wide.
+ *
  * @providesModule EdgenotesCard
  * @flow
  */
@@ -7,11 +14,10 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { values } from 'ramda'
 
-import { convertToRaw } from 'draft-js'
+import { EditorState, convertToRaw } from 'draft-js'
 import OldEdgenote from 'deprecated/OldEdgenote'
 import Edgenote from 'edgenotes/Edgenote'
 
-import { EditorState } from 'draft-js'
 import type { State } from 'redux/state'
 
 type OwnProps = { cardId: string }
@@ -26,17 +32,15 @@ function mapStateToProps (state: State, ownProps: OwnProps) {
 }
 
 const EdgenotesCard = ({ edgenoteSlugs, oldStyle }) => {
+  if (edgenoteSlugs.length === 0) return null
+
   const AnEdgenote = oldStyle ? OldEdgenote : Edgenote
 
-  if (edgenoteSlugs.length > 0) {
-    return (
-      <aside className={oldStyle ? 'edgenotes' : 'c-edgenotes-card pt-dark'}>
-        {edgenoteSlugs.map(slug => <AnEdgenote key={`${slug}`} slug={slug} />)}
-      </aside>
-    )
-  } else {
-    return null
-  }
+  return (
+    <aside className={oldStyle ? 'edgenotes' : 'c-edgenotes-card pt-dark'}>
+      {edgenoteSlugs.map(slug => <AnEdgenote key={`${slug}`} slug={slug} />)}
+    </aside>
+  )
 }
 
 export default connect(mapStateToProps, () => ({}))(EdgenotesCard)

--- a/app/javascript/edgenotes/index.jsx
+++ b/app/javascript/edgenotes/index.jsx
@@ -45,7 +45,7 @@ const EdgenotesCard = ({ edgenoteSlugs, oldStyle }) => {
 
 export default connect(mapStateToProps, () => ({}))(EdgenotesCard)
 
-function getEdgenoteSlugs (editorState: EditorState): string[] {
+export function getEdgenoteSlugs (editorState: EditorState): string[] {
   const rawContent = convertToRaw(editorState.getCurrentContent())
   return values(rawContent.entityMap)
     .filter(({ type }) => type === 'EDGENOTE')

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -62,7 +62,7 @@ export type Action =
   | ChangeCommentInProgressAction
   | AddCommentAction
   | RemoveCommentAction
-  | CreateEdgenoteAction
+  | AddEdgenoteAction
   | UpdateEdgenoteAction
   | HighlightEdgenoteAction
   | ActivateEdgenoteAction
@@ -824,16 +824,25 @@ export function deleteComment (id: string): ThunkAction {
 
 // EDGENOTE
 //
-export type CreateEdgenoteAction = {
-  type: 'CREATE_EDGENOTE',
+export function createEdgenote (): ThunkAction {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const { slug } = getState().caseData
+    return Orchard.graft(`cases/${slug}/edgenotes`, {}).then(
+      (edgenote: Edgenote) => {
+        dispatch(addEdgenote(edgenote.slug, edgenote))
+        return edgenote.slug
+      }
+    )
+  }
+}
+
+export type AddEdgenoteAction = {
+  type: 'ADD_EDGENOTE',
   slug: string,
   data: Edgenote,
 }
-export function createEdgenote (
-  slug: string,
-  data: Edgenote
-): CreateEdgenoteAction {
-  return { type: 'CREATE_EDGENOTE', slug, data }
+export function addEdgenote (slug: string, data: Edgenote): AddEdgenoteAction {
+  return { type: 'ADD_EDGENOTE', slug, data }
 }
 
 export type UpdateEdgenoteAction = {

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -64,6 +64,7 @@ export type Action =
   | RemoveCommentAction
   | AddEdgenoteAction
   | UpdateEdgenoteAction
+  | RemoveEdgenoteAction
   | HighlightEdgenoteAction
   | ActivateEdgenoteAction
   | RegisterToasterAction
@@ -856,6 +857,28 @@ export function updateEdgenote (
 ): UpdateEdgenoteAction {
   setUnsaved()
   return { type: 'UPDATE_EDGENOTE', slug, data }
+}
+
+export function deleteEdgenote (slug: string): ThunkAction {
+  return (dispatch: Dispatch) => {
+    if (
+      window.confirm(
+        'Are you sure you want to delete this Edgenote? This action cannot be undone.'
+      )
+    ) {
+      return Orchard.prune(`edgenotes/${slug}`).then(() =>
+        dispatch(removeEdgenote(slug))
+      )
+    }
+  }
+}
+
+export type RemoveEdgenoteAction = {
+  type: 'REMOVE_EDGENOTE',
+  slug: string,
+}
+function removeEdgenote (slug: string): RemoveEdgenoteAction {
+  return { type: 'REMOVE_EDGENOTE', slug }
 }
 
 export type HighlightEdgenoteAction = {

--- a/app/javascript/redux/reducers/edgenotesBySlug.js
+++ b/app/javascript/redux/reducers/edgenotesBySlug.js
@@ -3,12 +3,18 @@
  * @flow
  */
 
+import produce from 'immer'
+
 import type { EdgenotesState } from 'redux/state'
-import type { AddEdgenoteAction, UpdateEdgenoteAction } from 'redux/actions'
+import type {
+  AddEdgenoteAction,
+  UpdateEdgenoteAction,
+  RemoveEdgenoteAction,
+} from 'redux/actions'
 
 export default function edgenotesBySlug (
   state: EdgenotesState = ({ ...window.caseData.edgenotes }: EdgenotesState),
-  action: AddEdgenoteAction | UpdateEdgenoteAction
+  action: AddEdgenoteAction | UpdateEdgenoteAction | RemoveEdgenoteAction
 ): EdgenotesState {
   switch (action.type) {
     case 'ADD_EDGENOTE':
@@ -25,6 +31,11 @@ export default function edgenotesBySlug (
           ...action.data,
         },
       }
+
+    case 'REMOVE_EDGENOTE':
+      return produce(state, state => {
+        delete state[action.slug]
+      })
 
     default:
       return state

--- a/app/javascript/redux/reducers/edgenotesBySlug.js
+++ b/app/javascript/redux/reducers/edgenotesBySlug.js
@@ -4,14 +4,14 @@
  */
 
 import type { EdgenotesState } from 'redux/state'
-import type { CreateEdgenoteAction, UpdateEdgenoteAction } from 'redux/actions'
+import type { AddEdgenoteAction, UpdateEdgenoteAction } from 'redux/actions'
 
 export default function edgenotesBySlug (
   state: EdgenotesState = ({ ...window.caseData.edgenotes }: EdgenotesState),
-  action: CreateEdgenoteAction | UpdateEdgenoteAction
+  action: AddEdgenoteAction | UpdateEdgenoteAction
 ): EdgenotesState {
   switch (action.type) {
-    case 'CREATE_EDGENOTE':
+    case 'ADD_EDGENOTE':
       return {
         ...state,
         [action.slug]: action.data,

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -51,6 +51,8 @@ class Edgenote < ApplicationRecord
   include Mobility
   include Trackable
 
+  attribute :format, :string, default: 'aside'
+  attribute :style, :integer, default: 1 # :v2
   translates :caption, :content, :instructions, :image_url, :website_url,
              :embed_code, :photo_credit, :pdf_url, :pull_quote, :attribution,
              :call_to_action, :audio_url, :youtube_slug, fallbacks: true
@@ -62,6 +64,8 @@ class Edgenote < ApplicationRecord
 
   validates :format, inclusion: { in: %w[aside audio graphic link photo quote
                                          report video] }
+
+  before_create :ensure_slug_set
 
   # The name of the corresponding {Ahoy::Event}s
   # @see Trackable#event_name
@@ -77,5 +81,11 @@ class Edgenote < ApplicationRecord
 
   def to_param
     slug
+  end
+
+  private
+
+  def ensure_slug_set
+    self.slug ||= SecureRandom.uuid
   end
 end

--- a/flow-typed/npm/@blueprintjs/core_v1.6.x.js
+++ b/flow-typed/npm/@blueprintjs/core_v1.6.x.js
@@ -19,10 +19,10 @@ declare module '@blueprintjs/core' {
     | typeof undefined
 
   declare export class Intent {
-    static PRIMARY: PRIMARY,
-    static SUCCESS: SUCCESS,
-    static WARNING: WARNING,
-    static DANGER: DANGER,
+    static PRIMARY: PRIMARY;
+    static SUCCESS: SUCCESS;
+    static WARNING: WARNING;
+    static DANGER: DANGER;
   }
 
   declare export type TOP_LEFT = 'TOP_LEFT'
@@ -52,18 +52,18 @@ declare module '@blueprintjs/core' {
     | LEFT_TOP
 
   declare export class Position {
-    static TOP_LEFT: TOP_LEFT,
-    static TOP: TOP,
-    static TOP_RIGHT: TOP_RIGHT,
-    static RIGHT_TOP: RIGHT_TOP,
-    static RIGHT: RIGHT,
-    static RIGHT_BOTTOM: RIGHT_BOTTOM,
-    static BOTTOM_RIGHT: BOTTOM_RIGHT,
-    static BOTTOM: BOTTOM,
-    static BOTTOM_LEFT: BOTTOM_LEFT,
-    static LEFT_BOTTOM: LEFT_BOTTOM,
-    static LEFT: LEFT,
-    static LEFT_TOP: LEFT_TOP,
+    static TOP_LEFT: TOP_LEFT;
+    static TOP: TOP;
+    static TOP_RIGHT: TOP_RIGHT;
+    static RIGHT_TOP: RIGHT_TOP;
+    static RIGHT: RIGHT;
+    static RIGHT_BOTTOM: RIGHT_BOTTOM;
+    static BOTTOM_RIGHT: BOTTOM_RIGHT;
+    static BOTTOM: BOTTOM;
+    static BOTTOM_LEFT: BOTTOM_LEFT;
+    static LEFT_BOTTOM: LEFT_BOTTOM;
+    static LEFT: LEFT;
+    static LEFT_TOP: LEFT_TOP;
   }
 
   declare export type CLICK = 'CLICK'
@@ -77,72 +77,72 @@ declare module '@blueprintjs/core' {
     | HOVER_TARGET_ONLY
 
   declare export class PopoverInteractionKind {
-    static CLICK: CLICK,
-    static CLICK_TARGET_ONLY: CLICK_TARGET_ONLY,
-    static HOVER: HOVER,
-    static HOVER_TARGET_ONLY: HOVER_TARGET_ONLY,
+    static CLICK: CLICK;
+    static CLICK_TARGET_ONLY: CLICK_TARGET_ONLY;
+    static HOVER: HOVER;
+    static HOVER_TARGET_ONLY: HOVER_TARGET_ONLY;
   }
 
   //
   // Interfaces
   //
   declare export interface IProps {
-    className?: string,
+    className?: string;
   }
 
   declare export interface IActionProps {
-    disabled?: boolean,
-    text?: string,
-    iconName?: string,
-    onClick?: (SyntheticEvent<*>) => any,
+    disabled?: boolean;
+    text?: string;
+    iconName?: string;
+    onClick?: (SyntheticEvent<*>) => any;
   }
 
   declare export interface IBackdropProps {
-    backdropClassName?: string,
-    backdropProps?: HTMLDivElement,
-    canOutsideClickClose?: boolean,
-    hasBackdrop?: boolean,
+    backdropClassName?: string;
+    backdropProps?: HTMLDivElement;
+    canOutsideClickClose?: boolean;
+    hasBackdrop?: boolean;
   }
 
   declare export interface IControlledProps {
-    defaultValue?: string,
-    onChange?: (SyntheticInputEvent<*>) => any,
-    value?: string,
+    defaultValue?: string;
+    onChange?: (SyntheticInputEvent<*>) => any;
+    value?: string;
   }
 
   declare export interface IControlProps {
-    checked?: boolean,
-    defaultChecked?: boolean,
-    disabled?: boolean,
-    inputRef?: HTMLInputElement => any,
-    label?: string,
-    onChange?: (SyntheticInputEvent<*>) => any,
+    checked?: boolean;
+    defaultChecked?: boolean;
+    disabled?: boolean;
+    inputRef?: HTMLInputElement => any;
+    label?: string;
+    onChange?: (SyntheticInputEvent<*>) => any;
   }
 
   declare export interface IIntentProps {
-    intent?: IntentType,
+    intent?: IntentType;
   }
 
   declare export interface ILinkProps {
-    href?: string,
-    target?: '_self' | '_blank' | '_parent' | '_top',
+    href?: string;
+    target?: '_self' | '_blank' | '_parent' | '_top';
   }
 
   declare export interface IOptionProps {
-    className?: string,
-    disabled?: boolean,
-    label?: string,
-    value?: string,
+    className?: string;
+    disabled?: boolean;
+    label?: string;
+    value?: string;
   }
 
   declare export interface IOverlayableProps {
-    autoFocus?: boolean,
-    canEscapeKeyClose?: boolean,
-    enforceFocus?: boolean,
-    inline?: boolean,
-    lazy?: boolean,
-    onClose?: (SyntheticEvent<*>) => any,
-    transitionDuration?: number,
+    autoFocus?: boolean;
+    canEscapeKeyClose?: boolean;
+    enforceFocus?: boolean;
+    inline?: boolean;
+    lazy?: boolean;
+    onClose?: (SyntheticEvent<*>) => any;
+    transitionDuration?: number;
   }
 
   //
@@ -192,6 +192,14 @@ declare module '@blueprintjs/core' {
     } & IProps &
       IBackdropProps &
       IOverlayableProps
+  > {}
+
+  declare export class Icon extends React.Components<
+    {
+      iconName: string,
+      iconSize?: 'inherit' | 16 | 20,
+    } & IProps &
+      IIntentProps
   > {}
 
   declare export class InputGroup extends React.Component<
@@ -290,12 +298,12 @@ declare module '@blueprintjs/core' {
         position?: Position,
       } & IProps),
       container: ?HTMLElement
-    ): Toaster,
-    show(props: Toast): string,
-    update(key: string, props: Toast): void,
-    dismiss(key: string): void,
-    clear(): void,
-    getToasts(): Toast[],
+    ): Toaster;
+    show(props: Toast): string;
+    update(key: string, props: Toast): void;
+    dismiss(key: string): void;
+    clear(): void;
+    getToasts(): Toast[];
   }
 
   declare export class Tooltip extends React.Component<
@@ -317,6 +325,7 @@ declare module '@blueprintjs/core' {
       transitionDuration?: number,
       useSmartArrowPositioning?: boolean,
       useSmartPositioning?: boolean,
-    } & IIntentProps & IProps
+    } & IIntentProps &
+      IProps
   > {}
 }

--- a/flow-typed/npm/immer_vx.x.x.js
+++ b/flow-typed/npm/immer_vx.x.x.js
@@ -1,0 +1,8 @@
+declare module 'immer' {
+  declare export default function produce<T>(
+    baseState: T,
+    producer: (T) => mixed
+  ): T
+
+  declare export function setAutoFreeze(boolean): void
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "file-loader": "^1.1.6",
     "glob": "^7.1.1",
     "history": "^4.6.1",
+    "immer": "^0.7.0",
     "immutability-helper": "^2.4.0",
     "intl": "^1.2.5",
     "js-yaml": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3773,6 +3773,10 @@ ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
+immer@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-0.7.0.tgz#926200dcf5453815e477b2470a49137e9201df1b"
+
 immutability-helper@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.4.0.tgz#00d421e2957c17f0f0781475f05ffd837e73458d"


### PR DESCRIPTION
We had been requiring editors to manually input Edgenote slugs when
attaching an Edgenote: a unique slug would create a new Edgenote, the
slug of another Edgenote on the case would reattach it, and a slug of a
different case’s Edgenote would... fail silently. This was always a
stop-gap.

This implements an interface for Edgenote creation and reattachment that
makes a lot more sense. Since we’re no longer using Edgenote slugs as
URL parameters, there’s no reason for editors to have to set them
manually: when there are no Edgenotes to reattach, the new Edgenote
button just automatically creates one. When there are Edgenotes that
have been deleted from one part of a case and could be reattached, we
stop and present a dialog offering the editor the choice to reattach or
create new.

To make this split workflow work, the toolbar button calls a function
that returns a promise of an Edgenote slug. When resolved, a
DraftEntity is created with that slug and added to the card. The
promise is resolved either by the POST request creating a new Edgenote
or by the user’s click on an Edgenote in the EdgenoteLibrary.