### PR TITLE
Support comments that are not tied to a specific bit of text

### DIFF
--- a/app/javascript/conversation/CommentThreadItem.jsx
+++ b/app/javascript/conversation/CommentThreadItem.jsx
@@ -6,9 +6,7 @@
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { connect } from 'react-redux'
-import { injectIntl } from 'react-intl'
-
-import { FormattedMessage } from 'react-intl'
+import { injectIntl, FormattedMessage } from 'react-intl'
 import Truncate from 'react-truncate'
 import { matchPath, Link, withRouter } from 'react-router-dom'
 import { EditorState } from 'draft-js'
@@ -40,7 +38,8 @@ function mapStateToProps (
     originalHighlightText,
     readers,
   } = commentThreadsById[id]
-  const { position: pageNumber } = pagesById[cardsById[cardId].pageId]
+  const { position: pageNumber } =
+    cardId != null ? pagesById[cardsById[cardId].pageId] : {}
 
   const mostRecentComment =
     commentsById[commentIds[commentIds.length - 1]] || {}
@@ -113,20 +112,20 @@ const CommentThreadItem = ({
     onMouseEnter={handleMouseEnter}
     onMouseLeave={handleMouseLeave}
   >
-    {open && <ScrollIntoView />}
-
-    <CommentThreadBreadcrumbs>
-      <CommentThreadBreadcrumb>
-        <FormattedMessage
-          id="case.pageN"
-          defaultMessage={`Page {pageNumber, number}`}
-          values={{ pageNumber }}
-        />
-      </CommentThreadBreadcrumb>
-      <CommentThreadBreadcrumb quotation>
-        {originalHighlightText}
-      </CommentThreadBreadcrumb>
-    </CommentThreadBreadcrumbs>
+    {originalHighlightText && (
+      <CommentThreadBreadcrumbs>
+        <CommentThreadBreadcrumb>
+          <FormattedMessage
+            id="case.pageN"
+            defaultMessage={`Page {pageNumber, number}`}
+            values={{ pageNumber }}
+          />
+        </CommentThreadBreadcrumb>
+        <CommentThreadBreadcrumb quotation>
+          {originalHighlightText}
+        </CommentThreadBreadcrumb>
+      </CommentThreadBreadcrumbs>
+    )}
 
     <MostRecentComment>
       {mostRecentCommentContent ? (
@@ -140,6 +139,8 @@ const CommentThreadItem = ({
         </Grey>
       )}
     </MostRecentComment>
+
+    {open && <ScrollIntoView />}
 
     <ConversationMetadata>
       <Indenticons>

--- a/app/javascript/conversation/FirstPostForm.jsx
+++ b/app/javascript/conversation/FirstPostForm.jsx
@@ -94,6 +94,8 @@ const Input = styled.div.attrs({ className: 'pt-card pt-elevation-1' })`
   font-size: 17px;
   line-height: 1.3;
 
+  margin-top: 28px;
+
   & .public-DraftEditorPlaceholder-root {
     margin-bottom: -20px;
     pointer-events: none;

--- a/app/javascript/conversation/LeadComment.jsx
+++ b/app/javascript/conversation/LeadComment.jsx
@@ -28,13 +28,13 @@ import type { Dispatch } from 'redux/actions'
 import type { State, Page, Comment } from 'redux/state'
 
 type OwnProps = {
-  cardPosition: number,
+  cardPosition: ?number,
   inSitu: boolean,
-  inSituPath: string,
+  inSituPath: ?string,
   intl: IntlShape,
   leadComment: ?Comment,
-  originalHighlightText: string,
-  page: Page,
+  originalHighlightText: ?string,
+  page: ?Page,
   reader: { imageUrl: ?string, hashKey: string, name: string },
   responseCount: number,
   threadId: string,
@@ -84,73 +84,79 @@ const LeadComment = ({
   responseCount,
   threadId,
   onCancel,
-}: Props) => [
-  <LeadCommenter key="1">
-    <Identicon presentational width={32} reader={reader} />
-    <cite>{reader.name}</cite>
-  </LeadCommenter>,
+}: Props) => (
+  <React.Fragment>
+    <LeadCommenter>
+      <Identicon presentational width={32} reader={reader} />
+      <cite>{reader.name}</cite>
+    </LeadCommenter>
 
-  <CommentThreadLocation key="2">
-    <CommentThreadBreadcrumbs>
-      <CommentThreadBreadcrumb>
-        {inSitu ? (
-          <FormattedMessage
-            id="conversation.commentsOnPageNumber"
-            defaultMessage="Comments on Page {position, number}"
-            values={{ position: page.position }}
-          />
-        ) : (
-          <FormattedMessage
-            id="conversation.commentsOnPage"
-            defaultMessage="Comments on “{title}”"
-            values={{ title: page.title }}
-          />
-        )}
-      </CommentThreadBreadcrumb>
-      <CommentThreadBreadcrumb>
-        <FormattedMessage
-          id="conversation.cardN"
-          defaultMessage="Card {cardPosition}"
-          values={{ cardPosition }}
-        />
-      </CommentThreadBreadcrumb>
-    </CommentThreadBreadcrumbs>
-    <HighlightedText disabled={inSitu}>
-      <Link
-        to={inSituPath}
-        className="CommentThread__metadata__text"
-        style={styles.purpleHighlight}
-      >
-        {originalHighlightText}
-      </Link>
-    </HighlightedText>
-  </CommentThreadLocation>,
+    {page != null &&
+      inSituPath != null && (
+        <CommentThreadLocation>
+          <CommentThreadBreadcrumbs>
+            <CommentThreadBreadcrumb>
+              {inSitu ? (
+                <FormattedMessage
+                  id="conversation.commentsOnPageNumber"
+                  defaultMessage="Comments on Page {position, number}"
+                  values={{ position: page.position }}
+                />
+              ) : (
+                <FormattedMessage
+                  id="conversation.commentsOnPage"
+                  defaultMessage="Comments on “{title}”"
+                  values={{ title: page.title }}
+                />
+              )}
+            </CommentThreadBreadcrumb>
+            <CommentThreadBreadcrumb>
+              <FormattedMessage
+                id="conversation.cardN"
+                defaultMessage="Card {cardPosition}"
+                values={{ cardPosition }}
+              />
+            </CommentThreadBreadcrumb>
+          </CommentThreadBreadcrumbs>
+          <HighlightedText disabled={inSitu}>
+            <Link
+              to={inSituPath}
+              className="CommentThread__metadata__text"
+              style={styles.purpleHighlight}
+            >
+              {originalHighlightText}
+            </Link>
+          </HighlightedText>
+        </CommentThreadLocation>
+      )}
 
-  leadComment ? (
-    <LeadCommentContents key="3">
-      <Row>
-        <SmallGreyText>
-          <ConversationTimestamp value={leadComment.timestamp} />
-        </SmallGreyText>
-        {readerCanDeleteComments &&
-          responseCount === 0 && (
-            <DeleteButton
-              aria-label={intl.formatMessage({
-                id: 'comments.deleteCommentThread',
-                defaultMessage: 'Delete comment thread',
-              })}
-              onClick={handleDeleteThread}
-            />
-          )}
-      </Row>
-      <blockquote>
-        <StyledComment markdown={leadComment.content} />
-      </blockquote>
-    </LeadCommentContents>
-  ) : (
-    <FirstPostForm key="3" threadId={threadId} onCancel={onCancel} />
-  ),
-]
+    {leadComment ? (
+      <LeadCommentContents>
+        <Row>
+          <SmallGreyText>
+            <ConversationTimestamp value={leadComment.timestamp} />
+          </SmallGreyText>
+          {readerCanDeleteComments &&
+            responseCount === 0 && (
+              <DeleteButton
+                aria-label={intl.formatMessage({
+                  id: 'comments.deleteCommentThread',
+                  defaultMessage: 'Delete comment thread',
+                })}
+                onClick={handleDeleteThread}
+              />
+            )}
+        </Row>
+        <blockquote>
+          <StyledComment markdown={leadComment.content} />
+        </blockquote>
+      </LeadCommentContents>
+    ) : (
+      <FirstPostForm key="3" threadId={threadId} onCancel={onCancel} />
+    )}
+  </React.Fragment>
+)
+
 export default injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(LeadComment)
 )

--- a/app/javascript/conversation/NewUnattachedCommentButton.jsx
+++ b/app/javascript/conversation/NewUnattachedCommentButton.jsx
@@ -1,0 +1,61 @@
+/**
+ * This is the first row of the sidebar of the conversation view which prompts
+ * readers to write a new response. Responses created in the general
+ * conversation view are not tied to a specific segment of text, so they are
+ * called “unattached.”
+ *
+ * @providesModule NewUnattachedCommentButton
+ * @flow
+ */
+
+import * as React from 'react'
+import styled from 'styled-components'
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
+import { FormattedMessage } from 'react-intl'
+
+import { createUnattachedCommentThread } from 'redux/actions'
+
+import type { ContextRouter } from 'react-router-dom'
+
+type Props = ContextRouter & {
+  createUnattachedCommentThread: typeof createUnattachedCommentThread,
+}
+const NewUnattachedCommentButton = ({
+  createUnattachedCommentThread,
+  history,
+}: Props) => (
+  <NewUnattachedButtonContainer>
+    <FormattedMessage
+      id="conversation.joinConversation"
+      defaultMessage="Join the conversation"
+    />
+    <button
+      className="pt-button pt-intent-primary pt-icon-edit"
+      onClick={() =>
+        createUnattachedCommentThread().then(id =>
+          history.push(`/conversation/${id}`)
+        )
+      }
+    >
+      <FormattedMessage
+        id="comments.writeNew"
+        defaultMessage="Write a new response"
+      />
+    </button>
+  </NewUnattachedButtonContainer>
+)
+
+export default connect(null, {
+  createUnattachedCommentThread,
+})(withRouter(NewUnattachedCommentButton))
+
+const NewUnattachedButtonContainer = styled.div`
+  padding: 14px 18px;
+  background-color: #dddcd6;
+  mix-blend-mode: darken;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid #bfbdac;
+`

--- a/app/javascript/conversation/RecentCommentThreads.jsx
+++ b/app/javascript/conversation/RecentCommentThreads.jsx
@@ -13,6 +13,7 @@ import { NonIdealState } from '@blueprintjs/core'
 import { CoverImageContainer } from 'overview/BillboardTitle'
 import CommunityChooser from 'overview/CommunityChooser'
 import CommentThreadItem from 'conversation/CommentThreadItem'
+import NewUnattachedCommentButton from 'conversation/NewUnattachedCommentButton'
 import ScrollView from 'utility/ScrollView'
 
 import type { State } from 'redux/state'
@@ -31,7 +32,6 @@ function mapStateToProps ({ caseData, ui }: State) {
 const RecentCommentThreads = ({
   activeCommunity,
   coverUrl,
-  intl,
   mostRecentCommentThreads,
 }) => (
   <Container>
@@ -40,15 +40,18 @@ const RecentCommentThreads = ({
       <CommunityChooser />
     </Shadow>
     <ScrollView maxHeightOffset="215px">
-      {mostRecentCommentThreads == null ? (
-        <Loading />
-      ) : mostRecentCommentThreads.length > 0 ? (
-        mostRecentCommentThreads.map(id => (
-          <CommentThreadItem key={id} id={id} />
-        ))
-      ) : (
-        <NoComments activeCommunity={activeCommunity} />
-      )}
+      <React.Fragment>
+        <NewUnattachedCommentButton />
+        {mostRecentCommentThreads == null ? (
+          <Loading />
+        ) : mostRecentCommentThreads.length > 0 ? (
+          mostRecentCommentThreads.map(id => (
+            <CommentThreadItem key={id} id={id} />
+          ))
+        ) : (
+          <NoComments activeCommunity={activeCommunity} />
+        )}
+      </React.Fragment>
     </ScrollView>
   </Container>
 )
@@ -95,12 +98,6 @@ const NoComments = injectIntl(({ activeCommunity, intl }) => (
       }
     )}
     // action={
-    //   <button className="pt-button pt-intent-primary pt-icon-edit">
-    //     <FormattedMessage
-    //       id="comments.writeNew"
-    //       defaultMessage="Write a new response"
-    //     />
-    //   </button>
     // }
   />
 ))

--- a/app/javascript/conversation/Responses.jsx
+++ b/app/javascript/conversation/Responses.jsx
@@ -9,8 +9,8 @@ import { injectIntl } from 'react-intl'
 import styled from 'styled-components'
 import { groupWith } from 'ramda'
 
-import { StyledComment } from 'conversation/shared'
 import Identicon from 'shared/Identicon'
+import { StyledComment } from 'conversation/shared'
 import { SmallGreyText, ConversationTimestamp } from 'conversation/shared'
 
 import { deleteComment } from 'redux/actions'

--- a/app/javascript/conversation/SelectedCommentThread.jsx
+++ b/app/javascript/conversation/SelectedCommentThread.jsx
@@ -36,12 +36,12 @@ type StateProps =
   | {|
       commentThreadFound: true,
       activeReader: ?Reader,
-      cardPosition: number,
-      inSituPath: string,
+      cardPosition: ?number,
+      inSituPath: ?string,
       leadComment: ?Comment,
       leadCommenter: { hashKey: string, imageUrl: ?string, name: string },
-      originalHighlightText: string,
-      page: Page,
+      originalHighlightText: ?string,
+      page: ?Page,
       readerId: number,
       responses: Comment[],
       threadId: string,
@@ -59,14 +59,17 @@ function mapStateToProps (
 
   const { reader: activeReader } = caseData
   const { originalHighlightText, cardId, readerId, readers } = commentThread
-  const { position: cardPosition, pageId } = cardsById[cardId]
-  const page = pagesById[pageId]
+
   const leadCommenter = readers[0] || activeReader
   const comments = commentThread.commentIds.map(id => commentsById[id])
   const leadComment: ?Comment = comments[0]
   const [, ...responses] = comments
 
-  const inSituPath = `/${page.position}/cards/${cardId}/comments/${threadId}`
+  const { position: cardPosition, pageId } =
+    cardId != null ? cardsById[cardId] : {}
+  const page = pageId != null ? pagesById[pageId] : null
+  const inSituPath =
+    cardId && page && `/${page.position}/cards/${cardId}/comments/${threadId}`
 
   return {
     commentThreadFound: true,

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -740,11 +740,11 @@ export function deleteCommentThread (threadId: string): ThunkAction {
 export type RemoveCommentThreadAction = {
   type: 'REMOVE_COMMENT_THREAD',
   threadId: string,
-  cardId: string,
+  cardId: ?string,
 }
 function removeCommentThread (
   threadId: string,
-  cardId: string
+  cardId: ?string
 ): RemoveCommentThreadAction {
   return { type: 'REMOVE_COMMENT_THREAD', threadId, cardId }
 }

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -708,6 +708,19 @@ export function createCommentThread (
   }
 }
 
+export function createUnattachedCommentThread (): ThunkAction {
+  return async (dispatch: Dispatch, getState: GetState) => {
+    const { slug } = getState().caseData
+    const newCommentThread = (await Orchard.graft(
+      `cases/${slug}/comment_threads`,
+      { commentThread: {}}
+    ): CommentThread)
+
+    dispatch(addCommentThread(newCommentThread))
+    return newCommentThread.id
+  }
+}
+
 export type AddCommentThreadAction = {
   type: 'ADD_COMMENT_THREAD',
   data: CommentThread,

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -193,16 +193,16 @@ export type Comment = {
 }
 
 export type CommentThread = {
-  blockIndex: number,
-  cardId: string,
+  blockIndex: ?number,
+  cardId: ?string,
   commentIds: string[],
   commentsCount: number,
   id: string,
   length: number,
-  originalHighlightText: string,
+  originalHighlightText: ?string,
   readerId: number,
   readers: { imageUrl: ?string, hashKey: string, name: string }[],
-  start: number,
+  start: ?number,
 }
 
 export type Community = {

--- a/app/services/comment_thread_range_calculator.rb
+++ b/app/services/comment_thread_range_calculator.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-# Calculates the correct positioning of the comment_thread in its card’s text
-# by looking for the first occurance of its highlight text. It is the consumer’s
-# responsibility to ensure that substring is unique.
+# Calculates the correct positioning of the comment_thread in its card’s text,
+# if it is attached to a card, by looking for the first occurance of its
+# highlight text. It is the consumer’s responsibility to ensure that substring
+# is unique.
 class CommentThreadRangeCalculator
   attr_reader :block_index, :start
 
   def initialize(comment_thread)
     @comment_thread = comment_thread
-    search
+    search unless @comment_thread.card.nil?
   end
 
   def length

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     resources :cases, only: %i[index show new create update], param: :slug do
       resources :activities, only: %i[create]
 
-      resources :comment_threads, only: %i[index]
+      resources :comment_threads, only: %i[index create]
 
       resources :communities, only: %i[index]
 


### PR DESCRIPTION
While it’s an important innovation to focus conversation by allowing readers to annotate a specific part of a case’s text and branch a conversation off at that point, some comments apply equally to the entire case. This is especially true of the kinds of instructor reports we’ll solicit in the instructors-only community to come. This PR allows for comments that are not tied to a specific bit of text but are rather generally tied to the case at large. They only appear in the Conversation view.

Closes #184 