### PR TITLE
Communicate errors that come up in direct upload

### DIFF
--- a/app/javascript/packs/file_upload.js
+++ b/app/javascript/packs/file_upload.js
@@ -60,17 +60,6 @@ addEventListener('direct-upload:progress', ({ detail }) => {
   progressBar.style.width = `${progress}%`
 })
 
-addEventListener('direct-upload:error', event => {
-  event.preventDefault()
-  const { id, error } = event.detail
-  const progressBar = document.getElementById(`direct-upload-progress-${id}`)
-  if (progressBar == null) return
-
-  progressBar.classList.add('pt-intent-danger')
-  progressBar.classList.add('pt-no-animation')
-  progressBar.setAttribute('title', error)
-})
-
 addEventListener('direct-upload:end', ({ detail }) => {
   const { id } = detail
   const progressBar = document.getElementById(`direct-upload-progress-${id}`)


### PR DESCRIPTION
The code being deleted was supposed to show the error and make the
progress bar red, but it didn’t work because the progress bar was
immediately removed. Deleting it falls back to the activestorage default
of alert()