### PR TITLE
Use friendly_id to manage case slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'redis', '~> 3.0'
 # Models
 gem 'acts_as_list', git: 'https://github.com/swanandp/acts_as_list.git', ref: '2811810'
 gem 'draper'
+gem 'friendly_id'
 gem 'kaminari'
 gem 'memoist'
 gem 'time_for_a_boolean', git: 'https://github.com/calebthompson/time_for_a_boolean'

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'redis', '~> 3.0'
 # Models
 gem 'acts_as_list', git: 'https://github.com/swanandp/acts_as_list.git', ref: '2811810'
 gem 'draper'
-gem 'friendly_id'
+gem 'friendly_id', git: 'https://github.com/norman/friendly_id.git', ref: 'a29e7d'
 gem 'kaminari'
 gem 'memoist'
 gem 'time_for_a_boolean', git: 'https://github.com/calebthompson/time_for_a_boolean'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,8 @@ GEM
     foreman (0.84.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
+    friendly_id (5.2.3)
+      activerecord (>= 4.0.0)
     geocoder (1.4.4)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -488,6 +490,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
+  friendly_id
   groupdate
   guard-rspec
   haml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,14 @@ GIT
       omniauth
 
 GIT
+  remote: https://github.com/norman/friendly_id.git
+  revision: a29e7d7cc280d7d46c181f58fabd7cc9be67eefe
+  ref: a29e7d
+  specs:
+    friendly_id (5.2.3)
+      activerecord (>= 4.0.0)
+
+GIT
   remote: https://github.com/pchaganti/doc_to_dash
   revision: 44029a791b3b6f9bd79a79fa50a08b9c77a8407a
   specs:
@@ -195,8 +203,6 @@ GEM
     foreman (0.84.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
-    friendly_id (5.2.3)
-      activerecord (>= 4.0.0)
     geocoder (1.4.4)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -490,7 +496,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
-  friendly_id
+  friendly_id!
   groupdate
   guard-rspec
   haml

--- a/app/assets/stylesheets/admin.sass
+++ b/app/assets/stylesheets/admin.sass
@@ -44,9 +44,11 @@ div.window.window-admin
 
 .admin
   padding: 2em
+  line-height: initial
 
   &--centered
     margin: 0 auto
+    max-width: 30em
 
   &__title
     font-family: $sansFont

--- a/app/channels/forum_channel.rb
+++ b/app/channels/forum_channel.rb
@@ -5,7 +5,7 @@
 class ForumChannel < ApplicationCable::Channel
   def subscribed
     current_reader.reload
-    kase = Case.find_by_slug(params[:case_slug])
+    kase = Case.friendly.find(params[:case_slug])
     forum = current_reader.active_community.forums.find_by case: kase
     stream_for forum
   end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -41,7 +41,7 @@ class ActivitiesController < ApplicationController
   private
 
   def set_case
-    @case = Case.find_by_slug params[:case_slug]
+    @case = Case.friendly.find params[:case_slug]
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -70,15 +70,20 @@ class CasesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_case
-    slug = params[:slug] || params[:case_slug]
-    @case = Case.where(slug: slug).includes(
-      :podcasts,
-      :edgenotes,
-      activities: %i[case_element card],
-      pages: %i[case_element cards],
-      cards: [comment_threads: [:reader, comments: [:reader]]],
-      enrollments: [:reader]
-    ).first.decorate
+    @case = Case.friendly
+                .includes(
+                  :podcasts, :edgenotes,
+                  activities: %i[case_element card],
+                  pages: %i[case_element cards],
+                  cards: [comment_threads: [:reader, comments: [:reader]]],
+                  enrollments: [:reader]
+                )
+                .find(slug)
+                .decorate
+  end
+
+  def slug
+    params[:slug] || params[:case_slug]
   end
 
   def set_libraries

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -39,17 +39,12 @@ class CasesController < ApplicationController
     authorize Case
 
     @case = Case.new(case_params)
-    @case.kicker ||= @case.slug.split('-').join(' ').titlecase
-    @case.title ||= ''
 
-    respond_to do |format|
-      if @case.save
-        format.html { redirect_to case_path(@case, anchor: '/edit') }
-        format.json { render json: @case, status: :created, location: @case }
-      else
-        format.html { render :new }
-        format.json { render json: @case.errors, status: :unprocessable_entity }
-      end
+    if @case.save
+      redirect_to case_path(@case, anchor: '/edit')
+    else
+      @case.errors.delete(:slug)
+      render :new
     end
   end
 

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -71,7 +71,7 @@ class CommentThreadsController < ApplicationController
   end
 
   def set_case
-    @case = Case.find_by_slug params[:case_slug] if params[:case_slug]
+    @case = Case.friendly.find params[:case_slug] if params[:case_slug]
   end
 
   def set_card

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -6,7 +6,7 @@ class CommunitiesController < ApplicationController
 
   # @route [GET] `/cases/case-slug/communities`
   def index
-    kase = Case.find_by_slug params[:case_slug]
+    kase = Case.friendly.find params[:case_slug]
     @communities = [GlobalCommunity.instance] +
                    Community.active_for_case(kase.id)
                             .merge(current_reader.communities)

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -11,7 +11,7 @@ class DeploymentsController < ApplicationController
   # @route [POST] `/groups/1/deployments`
   def create
     the_group = Group.find params[:group_id]
-    the_case = Case.find_by_slug params[:case_slug]
+    the_case = Case.friendly.find params[:case_slug]
 
     @deployment = Deployment.find_or_initialize_by(
       group: the_group, case: the_case

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -37,7 +37,7 @@ class EnrollmentsController < ApplicationController
   private
 
   def set_enrollment
-    kase = Case.find_by_slug params[:case_slug]
+    kase = Case.friendly.find params[:case_slug]
     @enrollment = Enrollment.find_or_initialize_by case_id: kase.id,
                                                    reader_id: current_reader.id
   end

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -8,7 +8,7 @@ class FeaturesController < ApplicationController
     features = Case.where.not(id: enrolled)
                    .ordered
                    .limit(6)
-                   .pluck(:slug)
+                   .map(&:slug)
     render json: { features: features }
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -41,7 +41,7 @@ class PagesController < ApplicationController
   private
 
   def set_case
-    @case = Case.find_by_slug params[:case_slug]
+    @case = Case.friendly.find params[:case_slug]
   end
 
   def set_page

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -46,7 +46,7 @@ class PodcastsController < ApplicationController
   end
 
   def set_case
-    @case = Case.find_by_slug(params[:case_slug])
+    @case = Case.friendly.find(params[:case_slug])
   end
 
   # Only allow a trusted parameter "white list" through.

--- a/app/helpers/blueprint_form_builder.rb
+++ b/app/helpers/blueprint_form_builder.rb
@@ -42,7 +42,7 @@ class BlueprintFormBuilder < ActionView::Helpers::FormBuilder
 
     unless in_parens.nil?
       contents << ' '
-      contents << @template.content_tag(:span, "(#{in_parens})",
+      contents << @template.content_tag(:span, "(#{in_parens})".html_safe,
                                         class: 'pt-text-muted')
     end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -3,7 +3,7 @@
 # A case study in Gala with attributes for the case’s “metadata” (the catalog or
 # overview information) and associations for all the case’s constituent parts.
 #
-# @attr slug [String] a globally unique kabob-case identifier: the URL param
+# @attr slug [String] the URL param (managed by friendly_id)
 # @attr kicker [Translated<String>] a two or three word tagline for the case.
 #   This comes from newspapers: the little mini-headline appearing above the hed
 #   to which continuations of the article refer (e.g. “from CORRUPTION, A1”)
@@ -30,6 +30,9 @@
 class Case < ApplicationRecord
   include Comparable
   include Mobility
+  extend FriendlyId
+
+  friendly_id :kicker, use: %i[history mobility]
 
   translates :kicker, :title, :dek, :summary, :narrative, :learning_objectives,
              :audience, :classroom_timeline, :acknowledgements, fallbacks: true

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -32,7 +32,7 @@ class Case < ApplicationRecord
   include Mobility
   extend FriendlyId
 
-  friendly_id :kicker, use: %i[history mobility]
+  friendly_id :kicker, use: %i[history slugged]
 
   translates :kicker, :title, :dek, :summary, :narrative, :learning_objectives,
              :audience, :classroom_timeline, :acknowledgements, fallbacks: true
@@ -62,8 +62,8 @@ class Case < ApplicationRecord
 
   after_create :create_forum_for_universal_communities
 
-  validates :slug, presence: true,
-                   uniqueness: true,
+  validates :kicker, :title, :slug, presence: true
+  validates :slug, uniqueness: true,
                    format: { with: /\A[a-z0-9-]+\Z/ }
 
   time_for_a_boolean :featured

--- a/app/services/linker_service.rb
+++ b/app/services/linker_service.rb
@@ -49,7 +49,7 @@ class LinkerService
     end
 
     def kase
-      @case ||= Case.find_by_slug @launch_params[:case_slug]
+      @case ||= Case.friendly.find @launch_params[:case_slug]
     end
 
     def group

--- a/app/services/usage_reports_service.rb
+++ b/app/services/usage_reports_service.rb
@@ -36,7 +36,7 @@ class UsageReportsService
                        .limit(limit)
                        .count
                        .keys
-    slugs.map { |slug| Case.find_by_slug(slug) }
+    slugs.map { |slug| Case.friendly.find(slug) }
   end
 
   def number_of_new_comments

--- a/app/views/cases/new.html.haml
+++ b/app/views/cases/new.html.haml
@@ -1,7 +1,7 @@
 .admin.admin--centered
   .pt-card.pt-elevation-2
     = form_for @case, builder: BlueprintFormBuilder do |f|
-      %h1.admin__title= "New Case"
+      %h1.admin__title= t '.new_case'
 
       - if @case.errors.any?
         .pt-callout.pt-intent-danger.pt-icon-error.form__errors
@@ -9,12 +9,19 @@
           - @case.errors.full_messages.each do |msg|
             %div= msg
 
-      - slug_format = 'A unique string of lowercase letters or numbers separated by hyphens.'
-      = f.form_group :slug, in_parens: 'required',
-                            helper_text: slug_format do |f, error_classes|
+      = f.form_group :kicker,
+                     in_parens: t('forms.required'),
+                     helper_text: t('.short_noun_phrase') do |f, error_classes|
         .pt-input-group{class: error_classes}
-          %span.pt-icon.pt-icon-link
-          = f.text_field :slug, class: %w[pt-input], placeholder: 'example-slug'
+          %span.pt-icon.pt-icon-tag
+          = f.text_field :kicker, class: %w[pt-input]
+
+      = f.form_group :title,
+                     in_parens: t('forms.required'),
+                     helper_text: t('.the_main_question') do |f, error_classes|
+        .pt-input-group{class: error_classes}
+          %span.pt-icon.pt-icon-help
+          = f.text_field :title, class: %w[pt-input]
 
       = f.form_group :library_id do |f, error_classes|
         .pt-select.pt-fill{class: error_classes}

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w[new edit index session login logout users admin
+                             stylesheets assets javascripts images]
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it
+  # appends a UUID, separated by a single dash. You can configure the character
+  # used as the separator. If you're upgrading from FriendlyId 4, you may wish
+  # to replace this with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an
+  # undefined method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/locales/translations/en.yml
+++ b/config/locales/translations/en.yml
@@ -29,6 +29,7 @@ en:
         cover_url: Cover URL  #g
         edgenotes: Edgenotes  #g
         enrollments: Enrollments  #g
+        kicker: Short title
         narrative: Narrative #g
         podcasts: Podcasts  #g
         published: Published  #g
@@ -36,7 +37,7 @@ en:
         slug: Slug  #g
         summary: Summary #g
         tags: Tags  #g
-        title: Title #g
+        title: Question
 
       comment:
         comment_thread: :activerecord.models.comment_thread  #g

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1,10 +1,20 @@
 en:
+  forms:
+    required: required
   cases:
     case:
       forthcoming: Forthcoming
       translator:
         one: Translator
         many: Translators
+    new:
+      new_case: Create a New Case
+      short_noun_phrase: |
+        Choose a short noun phrase which identifies the topic of the case. This
+        appears above the main title in smaller text.
+      the_main_question: |
+        The main title should ask the primary question at the center of the
+        case.
   readers:
     form:
       my_account: 'My Account'

--- a/db/migrate/20180219152023_create_friendly_id_slugs.rb
+++ b/db/migrate/20180219152023_create_friendly_id_slugs.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           null: false
+      t.integer  :sluggable_id,   null: false
+      t.string   :sluggable_type, limit: 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, %i[slug sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, %i[slug sluggable_type scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -630,6 +630,39 @@ ALTER SEQUENCE forums_id_seq OWNED BY forums.id;
 
 
 --
+-- Name: friendly_id_slugs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE friendly_id_slugs (
+    id bigint NOT NULL,
+    slug character varying NOT NULL,
+    sluggable_id integer NOT NULL,
+    sluggable_type character varying(50),
+    scope character varying,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: friendly_id_slugs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE friendly_id_slugs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: friendly_id_slugs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE friendly_id_slugs_id_seq OWNED BY friendly_id_slugs.id;
+
+
+--
 -- Name: group_memberships; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1242,6 +1275,13 @@ ALTER TABLE ONLY forums ALTER COLUMN id SET DEFAULT nextval('forums_id_seq'::reg
 
 
 --
+-- Name: friendly_id_slugs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY friendly_id_slugs ALTER COLUMN id SET DEFAULT nextval('friendly_id_slugs_id_seq'::regclass);
+
+
+--
 -- Name: group_memberships id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1482,6 +1522,14 @@ ALTER TABLE ONLY enrollments
 
 ALTER TABLE ONLY forums
     ADD CONSTRAINT forums_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: friendly_id_slugs friendly_id_slugs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY friendly_id_slugs
+    ADD CONSTRAINT friendly_id_slugs_pkey PRIMARY KEY (id);
 
 
 --
@@ -1895,6 +1943,34 @@ CREATE INDEX index_forums_on_case_id ON forums USING btree (case_id);
 --
 
 CREATE INDEX index_forums_on_community_id ON forums USING btree (community_id);
+
+
+--
+-- Name: index_friendly_id_slugs_on_slug_and_sluggable_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type ON friendly_id_slugs USING btree (slug, sluggable_type);
+
+
+--
+-- Name: index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope ON friendly_id_slugs USING btree (slug, sluggable_type, scope);
+
+
+--
+-- Name: index_friendly_id_slugs_on_sluggable_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_friendly_id_slugs_on_sluggable_id ON friendly_id_slugs USING btree (sluggable_id);
+
+
+--
+-- Name: index_friendly_id_slugs_on_sluggable_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_friendly_id_slugs_on_sluggable_type ON friendly_id_slugs USING btree (sluggable_type);
 
 
 --
@@ -2429,6 +2505,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180119170858'),
 ('20180129143420'),
 ('20180206151601'),
-('20180212172121');
+('20180212172121'),
+('20180219152023');
 
 

--- a/spec/factories/cases.rb
+++ b/spec/factories/cases.rb
@@ -3,13 +3,13 @@
 FactoryBot.define do
   factory :case do
     sequence(:slug) { |n| "#{Faker::Internet.slug(nil, '-')}#{n}" }
+    kicker { Faker::Hipster.words(2).join(' ').titlecase }
+    title { Faker::Hipster.sentence }
     commentable true
 
     trait :in_catalog do
       library
 
-      kicker { Faker::Hipster.words(2).join(' ').titlecase }
-      title { Faker::Hipster.sentence }
       dek { Faker::Hipster.sentence }
     end
 

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe Case, type: :model do
     expect(subject).to be_valid
   end
 
-  it 'is not valid without a slug' do
-    subject.slug = nil
+  it 'is not valid without a kicker' do
+    subject.kicker = nil
     expect(subject).to_not be_valid
+  end
+
+  it 'is generates a slug from the kicker if needed' do
+    subject.slug = nil
+    expect(subject).to be_valid
+    expect(subject.slug).not_to be_nil
   end
 
   it 'is not valid with an invalid slug' do


### PR DESCRIPTION
This way, case slugs can be automatically generated from kickers and can be changed while still keeping links active.

Migrations: **YES**
Post-deploy: `Case.find_each(&:save)` to create history entries