### PR TITLE
remove ActiveModelSerializers logger object

### DIFF
--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -2,9 +2,7 @@
 
 ActiveModelSerializers.config.key_transform = :camel_lower
 
-ActiveSupport::Notifications.unsubscribe(
-  ActiveModelSerializers::Logging::RENDER_EVENT
-)
+ActiveModelSerializers.logger = Logger.new(IO::NULL)
 
 ActiveModel::Serializer.class_eval do
   def self.for(resource, options = {})


### PR DESCRIPTION
@cbothner This should help avoid the issue with missing trace spans on Skylight.

Essentially, the issue is that `ActiveSupport::Notifications.unsubscribe` is a bit too eager when it comes to subscribers that match multiple patterns, and unsubscribing from one results in a lot of related subscriptions being canceled at the same time. Nullifying the logger accomplishes the same effect, and won't disable the Skylight subscriber.