### PR TITLE
Support concurrent editing of a case by pessimistically locking individual models as each user edits them

### DIFF
--- a/app/assets/stylesheets/Podcast.sass
+++ b/app/assets/stylesheets/Podcast.sass
@@ -24,6 +24,7 @@ $threeColumnCutoff: 930px
   &Player
     min-width: 20.3em
     flex: 0 2 30em
+    position: relative
 
     @media screen and (max-width: $threeColumnCutoff)
       margin: 1em

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -12,10 +12,10 @@ class ActivitiesController < ApplicationController
 
   # @route [POST] `/cases/case-slug/activities`
   def create
-    authorize @case, :update?
-
     @activity = Activity.new activity_params
     @activity.build_case_element case: @case
+
+    authorize @activity
 
     if @activity.save
       render @activity
@@ -26,7 +26,7 @@ class ActivitiesController < ApplicationController
 
   # @route [PATCH/PUT] `/activities/1`
   def update
-    authorize @activity.case
+    authorize @activity
 
     if @activity.update(activity_params)
       render @activity
@@ -37,7 +37,7 @@ class ActivitiesController < ApplicationController
 
   # @route [DELETE] `/activities/1`
   def destroy
-    authorize @activity.case
+    authorize @activity
 
     @activity.destroy
   end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -3,10 +3,12 @@
 # @see Activity
 class ActivitiesController < ApplicationController
   include BroadcastEdits
+  include VerifyLock
 
   before_action :authenticate_reader!
   before_action :set_activity, only: %i[show update destroy]
   before_action :set_case, only: [:create]
+  before_action -> { verify_lock_on @activity }, only: %i[update destroy]
 
   broadcast_edits to: :@activity
 

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -3,10 +3,12 @@
 # @see Card
 class CardsController < ApplicationController
   include BroadcastEdits
+  include VerifyLock
 
   before_action :authenticate_reader!, only: %i[create update destroy]
   before_action :set_page, only: [:create]
   before_action :set_card, only: %i[update destroy]
+  before_action -> { verify_lock_on @card }, only: %i[update destroy]
 
   broadcast_edits to: :@card
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -3,9 +3,11 @@
 # @see Case
 class CasesController < ApplicationController
   include BroadcastEdits
+  include VerifyLock
 
   before_action :authenticate_reader!, except: %i[index show]
   before_action :set_case, only: %i[show edit update destroy]
+  before_action -> { verify_lock_on @case }, only: %i[update destroy]
 
   broadcast_edits to: :@case
 

--- a/app/controllers/concerns/verify_lock.rb
+++ b/app/controllers/concerns/verify_lock.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# When a reader tries to update a lockable model, we check that the model is not
+# locked by someone else.
+module VerifyLock
+  extend ActiveSupport::Concern
+
+  private
+
+  def verify_lock_on(model)
+    return if !model.locked? || model.locked_by?(current_user)
+    render json: model, status: :locked
+  end
+end

--- a/app/controllers/edgenotes_controller.rb
+++ b/app/controllers/edgenotes_controller.rb
@@ -3,10 +3,12 @@
 # @see Edgenote
 class EdgenotesController < ApplicationController
   include BroadcastEdits
+  include VerifyLock
 
   before_action :set_edgenote, only: %i[show update destroy]
   before_action :set_case, only: [:create]
   before_action :set_cors_headers, only: [:show]
+  before_action -> { verify_lock_on @edgenote }, only: %i[update destroy]
 
   broadcast_edits to: :@edgenote
 

--- a/app/controllers/edgenotes_controller.rb
+++ b/app/controllers/edgenotes_controller.rb
@@ -14,9 +14,8 @@ class EdgenotesController < ApplicationController
 
   # @route [POST] `/cases/case-slug/edgenotes`
   def create
-    authorize @case, :update?
-
     @edgenote = @case.edgenotes.build
+    authorize @edgenote
 
     if @edgenote.save
       render partial: 'edgenote', locals: { edgenote: edgenote }
@@ -27,7 +26,7 @@ class EdgenotesController < ApplicationController
 
   # @route [PATCH/PUT] `/edgenotes/slug`
   def update
-    authorize @edgenote.case, :update?
+    authorize @edgenote
 
     if @edgenote.update(edgenote_params)
       render partial: 'edgenote', locals: { edgenote: edgenote }
@@ -38,7 +37,7 @@ class EdgenotesController < ApplicationController
 
   # @route [DELETE] `/edgenotes/slug`
   def destroy
-    authorize @edgenote.case, :update?
+    authorize @edgenote
 
     @edgenote.destroy
   end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# @see Lock
+class LocksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :authenticate_reader!
+
+  before_action :set_locks, only: %i[index]
+  before_action :set_lockable, only: %i[create]
+  before_action :set_lock, only: %i[destroy]
+
+  # @route [GET] `/cases/:slug/locks`
+  def index
+    render json: @locks
+  end
+
+  # @route [POST] `/locks`
+  def create
+    @lock = @lockable.lock_by current_user
+
+    if @lock.present?
+      render json: @lock
+    else
+      render json: @lockable.lock, status: :conflict
+    end
+  end
+
+  # @route [DELETE] `/locks/:id`
+  def destroy
+    @lock.lockable.unlock
+    head :no_content
+  end
+
+  private
+
+  def set_locks
+    kase = Case.friendly.find params[:case_slug]
+    @locks = kase.active_locks
+  end
+
+  def set_lockable
+    klass = params[:lock][:lockable_type].constantize
+    @lockable = klass.find params[:lock][:lockable_id]
+  rescue StandardError
+    head :unprocessable_entity
+  end
+
+  def set_lock
+    @lock = Lock.find params[:id]
+  end
+end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -2,7 +2,6 @@
 
 # @see Lock
 class LocksController < ApplicationController
-  skip_before_action :verify_authenticity_token
   before_action :authenticate_reader!
 
   before_action :set_locks, only: %i[index]

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -2,11 +2,15 @@
 
 # @see Lock
 class LocksController < ApplicationController
+  include BroadcastEdits
+
   before_action :authenticate_reader!
 
   before_action :set_locks, only: %i[index]
   before_action :set_lockable, only: %i[create]
   before_action :set_lock, only: %i[destroy]
+
+  broadcast_edits to: :@lock
 
   # @route [GET] `/cases/:slug/locks`
   def index

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -43,12 +43,18 @@ class LocksController < ApplicationController
 
   def set_lockable
     klass = params[:lock][:lockable_type].constantize
-    @lockable = klass.find params[:lock][:lockable_id]
-  rescue StandardError
+    param_name = lockable_param klass
+    @lockable = klass.find_by! param_name => params[:lock][:lockable_param]
+  rescue ActiveRecord::RecordNotFound, NameError
     head :unprocessable_entity
   end
 
   def set_lock
     @lock = Lock.find params[:id]
+  end
+
+  def lockable_param(klass)
+    return :id unless klass.respond_to? :friendly
+    klass.friendly_id_config.base
   end
 end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -21,7 +21,7 @@ class LocksController < ApplicationController
     @lock = @lockable.lock_by current_user
 
     if @lock.present?
-      render json: @lock
+      render json: @lock, status: :created
     else
       render json: @lockable.lock, status: :conflict
     end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -11,11 +11,13 @@ class LocksController < ApplicationController
 
   # @route [GET] `/cases/:slug/locks`
   def index
+    authorize @case, :update?
     render json: @locks
   end
 
   # @route [POST] `/locks`
   def create
+    authorize @lockable, :update?
     @lock = @lockable.lock_by current_user
 
     if @lock.present?
@@ -27,6 +29,7 @@ class LocksController < ApplicationController
 
   # @route [DELETE] `/locks/:id`
   def destroy
+    authorize @lock.lockable, :update?
     @lock.lockable.unlock
     head :no_content
   end
@@ -34,8 +37,8 @@ class LocksController < ApplicationController
   private
 
   def set_locks
-    kase = Case.friendly.find params[:case_slug]
-    @locks = kase.active_locks
+    @case = Case.friendly.find params[:case_slug]
+    @locks = @case.active_locks
   end
 
   def set_lockable

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,10 +12,10 @@ class PagesController < ApplicationController
 
   # @route [POST] `/cases/case-slug/pages`
   def create
-    authorize @case, :update?
-
     @page = Page.new page_params
     @page.build_case_element case: @case
+
+    authorize @page
 
     if @page.save
       render @page
@@ -26,7 +26,7 @@ class PagesController < ApplicationController
 
   # @route [PATCH/PUT] `/pages/1`
   def update
-    authorize @page.case, :update?
+    authorize @page
 
     if @page.update(page_params)
       render @page
@@ -37,7 +37,7 @@ class PagesController < ApplicationController
 
   # @route [DELETE] `/pages/1`
   def destroy
-    authorize @page.case, :update?
+    authorize @page
 
     @page.destroy
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,10 +3,12 @@
 # @see Page
 class PagesController < ApplicationController
   include BroadcastEdits
+  include VerifyLock
 
   before_action :authenticate_reader!, only: %i[create update destroy]
   before_action :set_case, only: [:create]
   before_action :set_page, only: %i[update destroy]
+  before_action -> { verify_lock_on @page }, only: %i[update destroy]
 
   broadcast_edits to: :@page
 

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -12,10 +12,10 @@ class PodcastsController < ApplicationController
 
   # @route [POST] `/cases/case-slug/podcasts`
   def create
-    authorize @case, :update?
-
     @podcast = Podcast.new podcast_params
     @podcast.build_case_element case: @case
+
+    authorize @podcast
 
     if @podcast.save
       render @podcast.decorate
@@ -26,7 +26,7 @@ class PodcastsController < ApplicationController
 
   # @route [PATCH/PUT] `/podcasts/1`
   def update
-    authorize @podcast.case, :update?
+    authorize @podcast
 
     if @podcast.update(podcast_params)
       render @podcast.decorate
@@ -37,7 +37,7 @@ class PodcastsController < ApplicationController
 
   # @route [DELETE] `/podcasts/1`
   def destroy
-    authorize @podcast.case, :update?
+    authorize @podcast
 
     @podcast.destroy
   end

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -3,10 +3,12 @@
 # @see Podcast
 class PodcastsController < ApplicationController
   include BroadcastEdits
+  include VerifyLock
 
   before_action :authenticate_reader!
   before_action :set_podcast, only: %i[show update destroy]
   before_action :set_case, only: [:create]
+  before_action -> { verify_lock_on @podcast }, only: %i[update destroy]
 
   broadcast_edits to: :@podcast
 

--- a/app/decorators/reader_decorator.rb
+++ b/app/decorators/reader_decorator.rb
@@ -8,7 +8,7 @@ class ReaderDecorator < ApplicationDecorator
 
     case size
     when :thumbnail
-      h.url_for(image.variant(thumbnail: '100x100^'))
+      polymorphic_path image.variant(thumbnail: '100x100^'), only_path: true
     end
   end
 end

--- a/app/javascript/card/CardContents.jsx
+++ b/app/javascript/card/CardContents.jsx
@@ -120,7 +120,7 @@ class CardContents extends React.Component<CardProps & { intl: IntlShape }, *> {
         theseCommentThreadsOpen={theseCommentThreadsOpen}
       >
         <Lock type="Card" param={id}>
-          {() => (
+          {({ onBeginEditing, onFinishEditing }) => (
             <React.Fragment>
               {theseCommentThreadsOpen ? <ScrollIntoView /> : null}
 
@@ -151,7 +151,9 @@ class CardContents extends React.Component<CardProps & { intl: IntlShape }, *> {
                   customStyleMap={styleMap}
                   editorState={editorState}
                   handleKeyCommand={handleKeyCommand}
+                  onFocus={onBeginEditing}
                   onChange={onChange}
+                  onBlur={onFinishEditing}
                 />
               </FocusContainer>
 

--- a/app/javascript/card/CardContents.jsx
+++ b/app/javascript/card/CardContents.jsx
@@ -19,6 +19,7 @@ import FormattingToolbar from 'draft/FormattingToolbar'
 import Statistics from 'utility/Statistics'
 import CitationTooltip from './CitationTooltip'
 import CommentThreadsTag from 'comments/CommentThreadsTag'
+import Lock from 'utility/Lock'
 import { OnScreenTracker } from 'utility/Tracker'
 import { FocusContainer } from 'utility/A11y'
 import { ScrollIntoView } from 'utility/ScrollView'
@@ -118,74 +119,82 @@ class CardContents extends React.Component<CardProps & { intl: IntlShape }, *> {
         editable={editable}
         theseCommentThreadsOpen={theseCommentThreadsOpen}
       >
-        {theseCommentThreadsOpen ? <ScrollIntoView /> : null}
+        <Lock type="Card" param={id}>
+          {() => (
+            <React.Fragment>
+              {theseCommentThreadsOpen ? <ScrollIntoView /> : null}
 
-        {editable && (
-          <FormattingToolbar
-            actions={{
-              code: false,
-              header: false,
-              blockquote: false,
-              addEdgenoteEntity: !nonNarrative,
-              addCitationEntity: !nonNarrative,
-            }}
-            editorState={editorState}
-            getEdgenote={getEdgenote}
-            onChange={onChange}
-          />
-        )}
-        {title}
-        <FocusContainer
-          active={!!(theseCommentThreadsOpen && acceptingSelection)}
-          priority={100}
-        >
-          <Editor
-            placeholder={intl.formatMessage({
-              id: 'cards.edit.writeSomething',
-            })}
-            readOnly={readOnly}
-            customStyleMap={styleMap}
-            editorState={editorState}
-            handleKeyCommand={handleKeyCommand}
-            onChange={onChange}
-          />
-        </FocusContainer>
+              {editable && (
+                <FormattingToolbar
+                  actions={{
+                    code: false,
+                    header: false,
+                    blockquote: false,
+                    addEdgenoteEntity: !nonNarrative,
+                    addCitationEntity: !nonNarrative,
+                  }}
+                  editorState={editorState}
+                  getEdgenote={getEdgenote}
+                  onChange={onChange}
+                />
+              )}
+              {title}
+              <FocusContainer
+                active={!!(theseCommentThreadsOpen && acceptingSelection)}
+                priority={100}
+              >
+                <Editor
+                  placeholder={intl.formatMessage({
+                    id: 'cards.edit.writeSomething',
+                  })}
+                  readOnly={readOnly}
+                  customStyleMap={styleMap}
+                  editorState={editorState}
+                  handleKeyCommand={handleKeyCommand}
+                  onChange={onChange}
+                />
+              </FocusContainer>
 
-        {commentable &&
-          solid && <CommentThreadsTag cardId={id} match={match} />}
+              {commentable &&
+                solid && <CommentThreadsTag cardId={id} match={match} />}
 
-        <Route
-          {...commentThreadsOpen(id)}
-          render={routeProps => (
-            <CommentThreadsCard
-              {...routeProps}
-              cardId={id}
-              addCommentThread={addCommentThread}
-            />
+              <Route
+                {...commentThreadsOpen(id)}
+                render={routeProps => (
+                  <CommentThreadsCard
+                    {...routeProps}
+                    cardId={id}
+                    addCommentThread={addCommentThread}
+                  />
+                )}
+              />
+
+              {citationOpenWithinCard && (
+                <CitationTooltip
+                  cardId={id}
+                  cardWidth={this.cardRef ? this.cardRef.clientWidth : 0}
+                  openedCitation={openedCitation}
+                  editable={editable}
+                />
+              )}
+
+              {editable &&
+                deletable && (
+                <DeleteCardButton id={id} onClick={handleDeleteCard} />
+              )}
+
+              {solid && !editable && <Statistics uri={`cards/${id}`} />}
+
+              <OnScreenTracker
+                targetKey={`cards/${id}`}
+                targetParameters={{
+                  name: 'read_card',
+                  card_id: parseInt(id, 10),
+                }}
+              />
+            </React.Fragment>
           )}
-        />
-
-        {citationOpenWithinCard && (
-          <CitationTooltip
-            cardId={id}
-            cardWidth={this.cardRef ? this.cardRef.clientWidth : 0}
-            openedCitation={openedCitation}
-            editable={editable}
-          />
-        )}
-
-        {editable &&
-          deletable && <DeleteCardButton id={id} onClick={handleDeleteCard} />}
-
-        {solid && !editable && <Statistics uri={`cards/${id}`} />}
-
-        <OnScreenTracker
-          targetKey={`cards/${id}`}
-          targetParameters={{
-            name: 'read_card',
-            card_id: parseInt(id, 10),
-          }}
-        />
+        </Lock>
       </Card>
     )
   }

--- a/app/javascript/catalog/MapView.jsx
+++ b/app/javascript/catalog/MapView.jsx
@@ -24,7 +24,9 @@ type Props = {
   intl: IntlShape,
   startingViewport: Viewport,
   title: { id: string },
+  onBeginEditing?: () => void,
   onChangeViewport?: Viewport => any,
+  onFinishEditing?: () => void,
 }
 type State = {
   hasError: boolean,
@@ -48,7 +50,12 @@ class MapViewController extends React.Component<Props, State> {
     this.setState({ openPin: '' })
   }
 
-  handleChangeViewport = (viewport: Viewport) => this.setState({ viewport })
+  handleChangeViewport = (viewport: Viewport) => {
+    this.setState({ viewport })
+    this.props.editing &&
+      this.props.onBeginEditing &&
+      this.props.onBeginEditing()
+  }
 
   handleClickPin = (caseSlug: string) => this.setState({ openPin: caseSlug })
 
@@ -61,11 +68,16 @@ class MapViewController extends React.Component<Props, State> {
       viewport: { ...viewport, zoom: viewport.zoom + 1 },
     }))
 
-  handleReset = () => this.setState({ viewport: this.props.startingViewport })
+  handleReset = () => {
+    this.setState({ viewport: this.props.startingViewport })
+    this.props.onFinishEditing && this.props.onFinishEditing()
+  }
 
-  handleSave = () =>
-    this.props.onChangeViewport &&
-    this.props.onChangeViewport(this.state.viewport)
+  handleSave = () => {
+    const { onChangeViewport, onFinishEditing } = this.props
+    onChangeViewport && onChangeViewport(this.state.viewport)
+    onFinishEditing && onFinishEditing()
+  }
 
   componentDidCatch () {
     this.setState({ hasError: true })

--- a/app/javascript/edgenotes/Edgenote.jsx
+++ b/app/javascript/edgenotes/Edgenote.jsx
@@ -155,11 +155,12 @@ class BaseEdgenoteFigure extends React.Component<Props> {
         {...conditionalHoverCallbacks}
       >
         <Lock type="Edgenote" param={slug}>
-          {({ onBeginEditing, onFinishEditing }) => (
+          {({ locked, onBeginEditing, onFinishEditing }) => (
             <React.Fragment>
               {editing && (
                 <EdgenoteEditor
                   contents={contents}
+                  locked={locked}
                   slug={slug}
                   onChange={onChange}
                   onClose={onFinishEditing}

--- a/app/javascript/edgenotes/Edgenote.jsx
+++ b/app/javascript/edgenotes/Edgenote.jsx
@@ -32,6 +32,7 @@ import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
 import { LabelForScreenReaders } from 'utility/A11y'
 import { acceptKeyboardClick } from 'shared/keyboard'
+import Lock from 'utility/Lock'
 import Statistics from 'utility/Statistics'
 import Tracker from 'utility/Tracker'
 import EdgenoteEditor from 'edgenotes/editor'
@@ -153,47 +154,57 @@ class BaseEdgenoteFigure extends React.Component<Props> {
         id={slug}
         {...conditionalHoverCallbacks}
       >
-        {editing && (
-          <EdgenoteEditor contents={contents} slug={slug} onChange={onChange} />
-        )}
+        <Lock type="Edgenote" param={slug}>
+          {() => (
+            <React.Fragment>
+              {editing && (
+                <EdgenoteEditor
+                  contents={contents}
+                  slug={slug}
+                  onChange={onChange}
+                />
+              )}
 
-        {embedded || <Statistics inline uri={`edgenotes/${slug}`} />}
+              {embedded || <Statistics inline uri={`edgenotes/${slug}`} />}
 
-        <ConditionalLink
-          tabIndex={isALink ? '0' : ''}
-          id={`edgenote-${slug}`}
-          role={isALink ? 'button' : undefined}
-          onClick={!isALink || active ? () => {} : activate}
-          onKeyPress={acceptKeyboardClick}
-        >
-          {this.renderQuotationSection() || this.renderImageSection()}
+              <ConditionalLink
+                tabIndex={isALink ? '0' : ''}
+                id={`edgenote-${slug}`}
+                role={isALink ? 'button' : undefined}
+                onClick={!isALink || active ? () => {} : activate}
+                onKeyPress={acceptKeyboardClick}
+              >
+                {this.renderQuotationSection() || this.renderImageSection()}
 
-          <Expansion contents={contents} expansion={expansion} />
+                <Expansion contents={contents} expansion={expansion} />
 
-          <Caption
-            contents={caption}
-            {...this._reduxProps()}
-            {...(pullQuote ? { selected: false } : {})} // overrides reduxProps
-          />
-          {this.renderCallToAction()}
-        </ConditionalLink>
-        <LabelForScreenReaders>
-          <a href={`#edgenote-highlight-${slug}`}>
-            <FormattedMessage id="edgenotes.edgenote.returnToNarrative" />
-          </a>
-        </LabelForScreenReaders>
+                <Caption
+                  contents={caption}
+                  {...this._reduxProps()}
+                  {...(pullQuote ? { selected: false } : {})} // overrides reduxProps
+                />
+                {this.renderCallToAction()}
+              </ConditionalLink>
+              <LabelForScreenReaders>
+                <a href={`#edgenote-highlight-${slug}`}>
+                  <FormattedMessage id="edgenotes.edgenote.returnToNarrative" />
+                </a>
+              </LabelForScreenReaders>
 
-        {editing || (
-          <Tracker
-            timerState={active ? 'RUNNING' : 'STOPPED'}
-            targetKey={`edgenotes/${slug}`}
-            targetParameters={{
-              name: 'visit_edgenote',
-              edgenoteSlug: slug,
-            }}
-            instantaneous={isALink}
-          />
-        )}
+              {editing || (
+                <Tracker
+                  timerState={active ? 'RUNNING' : 'STOPPED'}
+                  targetKey={`edgenotes/${slug}`}
+                  targetParameters={{
+                    name: 'visit_edgenote',
+                    edgenoteSlug: slug,
+                  }}
+                  instantaneous={isALink}
+                />
+              )}
+            </React.Fragment>
+          )}
+        </Lock>
       </Container>
     )
   }

--- a/app/javascript/edgenotes/Edgenote.jsx
+++ b/app/javascript/edgenotes/Edgenote.jsx
@@ -155,13 +155,15 @@ class BaseEdgenoteFigure extends React.Component<Props> {
         {...conditionalHoverCallbacks}
       >
         <Lock type="Edgenote" param={slug}>
-          {() => (
+          {({ onBeginEditing, onFinishEditing }) => (
             <React.Fragment>
               {editing && (
                 <EdgenoteEditor
                   contents={contents}
                   slug={slug}
                   onChange={onChange}
+                  onClose={onFinishEditing}
+                  onOpen={onBeginEditing}
                 />
               )}
 

--- a/app/javascript/edgenotes/editor/index.jsx
+++ b/app/javascript/edgenotes/editor/index.jsx
@@ -28,6 +28,7 @@ type Props = {
   changeEdgenote: typeof changeEdgenote,
   contents: Edgenote,
   intl: IntlShape,
+  locked: boolean,
   slug: string,
   updateLinkExpansionVisibility: typeof updateLinkExpansionVisibility,
   onChange: ($Shape<Edgenote>) => Promise<any>,
@@ -52,6 +53,10 @@ class EdgenoteEditor extends React.Component<Props, State> {
   componentWillReceiveProps (nextProps: Props) {
     if (this.props.slug !== nextProps.slug) {
       this.setState({ contents: nextProps.contents })
+    }
+
+    if (this.props.locked !== nextProps.locked && nextProps.locked) {
+      this.handleClose()
     }
   }
 

--- a/app/javascript/edgenotes/editor/index.jsx
+++ b/app/javascript/edgenotes/editor/index.jsx
@@ -31,6 +31,8 @@ type Props = {
   slug: string,
   updateLinkExpansionVisibility: typeof updateLinkExpansionVisibility,
   onChange: ($Shape<Edgenote>) => Promise<any>,
+  onClose?: () => void,
+  onOpen?: () => void,
   ...VisibilityChangeProps,
 }
 
@@ -87,8 +89,11 @@ class EdgenoteEditor extends React.Component<Props, State> {
     )
   }
 
-  handleOpen = () => this.setState({ open: true })
-  handleClose = () => this._close().then(this._reset())
+  handleOpen = () => this.setState({ open: true }, this.props.onOpen)
+  handleClose = () =>
+    this._close()
+      .then(this._reset())
+      .then(this.props.onClose)
 
   handleChangeContents = (attributes: $Shape<Edgenote>) =>
     this.setState(({ contents }: State) => ({
@@ -132,6 +137,7 @@ class EdgenoteEditor extends React.Component<Props, State> {
         )
       )
       .then(this._reset)
+      .then(this.props.onClose)
   }
 
   _close = () => new Promise(resolve => this.setState({ open: false }, resolve))

--- a/app/javascript/overview/AuthorsList.jsx
+++ b/app/javascript/overview/AuthorsList.jsx
@@ -24,13 +24,18 @@ class AuthorsList extends React.Component<
     canEdit: boolean,
     byline: Byline,
     onChange: Byline => any,
+    onStartEditing?: () => void,
+    onFinishEditing?: () => void,
   },
   { editing: boolean }
 > {
   state = { editing: false }
 
   handleStartEditing = (e: SyntheticEvent<*>) => {
-    if (this.props.canEdit) this.setState({ editing: true })
+    if (this.props.canEdit) {
+      this.setState({ editing: true })
+      this.props.onStartEditing && this.props.onStartEditing()
+    }
   }
 
   handleFinishEditing = (formState: ?AuthorsListFormState) => {
@@ -38,6 +43,7 @@ class AuthorsList extends React.Component<
     if (formState != null) {
       this.props.onChange(formState)
     }
+    this.props.onFinishEditing && this.props.onFinishEditing()
   }
 
   render () {

--- a/app/javascript/overview/Billboard.jsx
+++ b/app/javascript/overview/Billboard.jsx
@@ -68,9 +68,12 @@ const Billboard = ({
 }: Props) => (
   <Container>
     <Lock type="Case" param={slug}>
-      {() => (
+      {({ onBeginEditing, onFinishEditing }) => (
         <Fragment>
-          <BillboardTitle />
+          <BillboardTitle
+            onBeginEditing={onBeginEditing}
+            onFinishEditing={onFinishEditing}
+          />
           {editing || <CommunityChooser />}
 
           <div className="Card BillboardSnippet pt-light">
@@ -83,6 +86,9 @@ const Billboard = ({
                 onChange={value => {
                   updateCase({ dek: value })
                 }}
+                onEdit={onBeginEditing}
+                onCancel={onFinishEditing}
+                onConfirm={onFinishEditing}
               />
             </h3>
 
@@ -97,6 +103,9 @@ const Billboard = ({
                   disabled={!editing}
                   placeholder="Summarize the case in a short paragraph."
                   onChange={value => updateCase({ summary: value })}
+                  onEdit={onBeginEditing}
+                  onCancel={onFinishEditing}
+                  onConfirm={onFinishEditing}
                 />
               </div>
             </Less>
@@ -105,7 +114,11 @@ const Billboard = ({
               <LearningObjectives
                 disabled={!editing}
                 learningObjectives={learningObjectives}
-                onChange={value => updateCase({ learningObjectives: value })}
+                onChange={value => {
+                  updateCase({ learningObjectives: value })
+                  onBeginEditing()
+                }}
+                onStopChanging={onFinishEditing}
               />
             )}
 
@@ -123,7 +136,9 @@ const Billboard = ({
                 zoom: caseData.zoom || 1,
               }}
               title={{ id: 'activerecord.attributes.case.location' }}
+              onBeginEditing={onBeginEditing}
               onChangeViewport={(viewport: Viewport) => updateCase(viewport)}
+              onFinishEditing={onFinishEditing}
             />
           )}
         </Fragment>

--- a/app/javascript/overview/Billboard.jsx
+++ b/app/javascript/overview/Billboard.jsx
@@ -4,11 +4,13 @@
  */
 
 import React, { Fragment } from 'react'
+import styled from 'styled-components'
 import { connect } from 'react-redux'
 
 import { FormattedMessage } from 'react-intl'
 import { EditableText } from '@blueprintjs/core'
 
+import Lock from 'utility/Lock'
 import Less from 'utility/Less'
 import BillboardTitle from './BillboardTitle'
 import CommunityChooser from './CommunityChooser'
@@ -64,64 +66,77 @@ const Billboard = ({
   learningObjectives,
   caseData,
 }: Props) => (
-  <section className="Billboard">
-    <BillboardTitle />
-    {editing || <CommunityChooser />}
+  <Container>
+    <Lock type="Case" param={slug}>
+      {() => (
+        <Fragment>
+          <BillboardTitle />
+          {editing || <CommunityChooser />}
 
-    <div className="Card BillboardSnippet pt-light">
-      <h3 className="c-BillboardSnippet__dek">
-        <EditableText
-          multiline
-          value={dek}
-          disabled={!editing}
-          placeholder="In one concise sentence, provide background and an intriguing twist: get a student to read this case."
-          onChange={value => {
-            updateCase({ dek: value })
-          }}
-        />
-      </h3>
+          <div className="Card BillboardSnippet pt-light">
+            <h3 className="c-BillboardSnippet__dek">
+              <EditableText
+                multiline
+                value={dek}
+                disabled={!editing}
+                placeholder="In one concise sentence, provide background and an intriguing twist: get a student to read this case."
+                onChange={value => {
+                  updateCase({ dek: value })
+                }}
+              />
+            </h3>
 
-      <Less startOpen={!summary || summary.length < 500} disabled={editing}>
-        <div style={{ margin: 0 }}>
-          <EditableText
-            multiline
-            value={summary}
-            disabled={!editing}
-            placeholder="Summarize the case in a short paragraph."
-            onChange={value => updateCase({ summary: value })}
-          />
-        </div>
-      </Less>
+            <Less
+              startOpen={!summary || summary.length < 500}
+              disabled={editing}
+            >
+              <div style={{ margin: 0 }}>
+                <EditableText
+                  multiline
+                  value={summary}
+                  disabled={!editing}
+                  placeholder="Summarize the case in a short paragraph."
+                  onChange={value => updateCase({ summary: value })}
+                />
+              </div>
+            </Less>
 
-      {(learningObjectives || editing) && (
-        <LearningObjectives
-          disabled={!editing}
-          learningObjectives={learningObjectives}
-          onChange={value => updateCase({ learningObjectives: value })}
-        />
+            {(learningObjectives || editing) && (
+              <LearningObjectives
+                disabled={!editing}
+                learningObjectives={learningObjectives}
+                onChange={value => updateCase({ learningObjectives: value })}
+              />
+            )}
+
+            <FlagLinks languages={otherAvailableLocales} slug={slug} />
+          </div>
+
+          {(caseData.latitude || editing) && (
+            <MapView
+              cases={[caseData]}
+              editing={editing}
+              height={300}
+              startingViewport={{
+                latitude: caseData.latitude || 0,
+                longitude: caseData.longitude || 0,
+                zoom: caseData.zoom || 1,
+              }}
+              title={{ id: 'activerecord.attributes.case.location' }}
+              onChangeViewport={(viewport: Viewport) => updateCase(viewport)}
+            />
+          )}
+        </Fragment>
       )}
-
-      <FlagLinks languages={otherAvailableLocales} slug={slug} />
-    </div>
-
-    {(caseData.latitude || editing) && (
-      <MapView
-        cases={[caseData]}
-        editing={editing}
-        height={300}
-        startingViewport={{
-          latitude: caseData.latitude || 0,
-          longitude: caseData.longitude || 0,
-          zoom: caseData.zoom || 1,
-        }}
-        title={{ id: 'activerecord.attributes.case.location' }}
-        onChangeViewport={(viewport: Viewport) => updateCase(viewport)}
-      />
-    )}
-  </section>
+    </Lock>
+  </Container>
 )
 
 export default connect(mapStateToProps, { updateCase })(Billboard)
+
+const Container = styled.section.attrs({ className: 'Billboard' })`
+  position: relative;
+`
 
 type FlagLinksProps = { slug: string, languages: string[] }
 function FlagLinks ({ slug, languages }: FlagLinksProps) {

--- a/app/javascript/overview/BillboardTitle.jsx
+++ b/app/javascript/overview/BillboardTitle.jsx
@@ -55,9 +55,11 @@ type Props = {
   photoCredit: string,
   coverUrl: string,
   updateCase: typeof updateCase,
-  minimal: boolean,
+  minimal?: boolean,
   library: Library,
   links: $PropertyType<CaseDataState, 'links'>,
+  onBeginEditing?: () => void,
+  onFinishEditing?: () => void,
 } & Byline
 
 export const UnconnectedBillboardTitle = ({
@@ -74,6 +76,8 @@ export const UnconnectedBillboardTitle = ({
   minimal,
   library,
   links,
+  onBeginEditing,
+  onFinishEditing,
 }: Props) => {
   return (
     <CoverImageContainer src={coverUrl}>
@@ -105,6 +109,9 @@ export const UnconnectedBillboardTitle = ({
             disabled={!editing || minimal}
             placeholder="Snappy kicker"
             onChange={value => updateCase({ kicker: value })}
+            onEdit={onBeginEditing}
+            onCancel={onFinishEditing}
+            onConfirm={onFinishEditing}
           />
         </span>
         <EditableText
@@ -113,6 +120,9 @@ export const UnconnectedBillboardTitle = ({
           disabled={!editing || minimal}
           placeholder="What is the central question of the case?"
           onChange={value => updateCase({ title: value })}
+          onEdit={onBeginEditing}
+          onCancel={onFinishEditing}
+          onConfirm={onFinishEditing}
         />
       </h1>
 
@@ -125,6 +135,8 @@ export const UnconnectedBillboardTitle = ({
             acknowledgements,
           }}
           onChange={(value: Byline) => updateCase(value)}
+          onStartEditing={onBeginEditing}
+          onFinishEditing={onFinishEditing}
         />
       )}
 
@@ -135,6 +147,9 @@ export const UnconnectedBillboardTitle = ({
             disabled={!editing}
             placeholder={editing ? 'Photo credit' : ''}
             onChange={value => updateCase({ photoCredit: value })}
+            onEdit={onBeginEditing}
+            onCancel={onFinishEditing}
+            onConfirm={onFinishEditing}
           />
         )}
       </cite>

--- a/app/javascript/overview/LearningObjectives.jsx
+++ b/app/javascript/overview/LearningObjectives.jsx
@@ -6,6 +6,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import debounce from 'lodash.debounce'
 import { FormattedMessage } from 'react-intl'
 
 import SortableList, { createSortableInput } from 'utility/SortableList'
@@ -14,30 +15,38 @@ type Props = {
   disabled: boolean,
   learningObjectives: string[],
   onChange: (string[]) => any,
+  onStopChanging: () => any,
 }
-const LearningObjectives = ({
-  disabled,
-  learningObjectives,
-  onChange,
-}: Props) => (
-  <div>
-    <Label>
-      <FormattedMessage id="activerecord.attributes.case.learningObjectives" />
-    </Label>
-    {disabled ? (
-      <ul>
-        {learningObjectives.map((objective, i) => <li key={i}>{objective}</li>)}
-      </ul>
-    ) : (
-      <SortableList
-        items={learningObjectives || []}
-        newItem={''}
-        render={ObjectiveInput}
-        onChange={onChange}
-      />
-    )}
-  </div>
-)
+class LearningObjectives extends React.Component<Props> {
+  onStopChanging = debounce(this.props.onStopChanging, 200)
+  render () {
+    const { disabled, learningObjectives, onChange } = this.props
+    return (
+      <div>
+        <Label>
+          <FormattedMessage id="activerecord.attributes.case.learningObjectives" />
+        </Label>
+        {disabled ? (
+          <ul>
+            {learningObjectives.map((objective, i) => (
+              <li key={i}>{objective}</li>
+            ))}
+          </ul>
+        ) : (
+          <SortableList
+            items={learningObjectives || []}
+            newItem={''}
+            render={ObjectiveInput}
+            onChange={(...args) => {
+              onChange(...args)
+              this.onStopChanging()
+            }}
+          />
+        )}
+      </div>
+    )
+  }
+}
 
 export default LearningObjectives
 

--- a/app/javascript/podcast/CreditsList.jsx
+++ b/app/javascript/podcast/CreditsList.jsx
@@ -19,13 +19,18 @@ class CreditsList extends React.Component<
     canEdit: boolean,
     credits: PodcastCreditList,
     onChange: PodcastCreditList => any,
+    onStartEditing: () => void,
+    onFinishEditing: () => void,
   },
   { editing: boolean }
 > {
   state = { editing: false }
 
   handleStartEditing = () => {
-    if (this.props.canEdit) this.setState({ editing: true })
+    if (this.props.canEdit) {
+      this.setState({ editing: true })
+      this.props.onStartEditing()
+    }
   }
 
   handleFinishEditing = (formState: ?CreditsListFormState) => {
@@ -36,6 +41,7 @@ class CreditsList extends React.Component<
         hosts_string: formState.hosts.join(' • '),
       })
     }
+    this.props.onFinishEditing()
   }
 
   render () {

--- a/app/javascript/podcast/index.jsx
+++ b/app/javascript/podcast/index.jsx
@@ -105,7 +105,7 @@ class PodcastPlayer extends React.Component<*, { playing: boolean }> {
     return (
       <div className="PodcastPlayer pt-dark">
         <Lock type="Podcast" param={id}>
-          {() => (
+          {({ onBeginEditing, onFinishEditing }) => (
             <React.Fragment>
               <div
                 className="artwork"
@@ -141,6 +141,9 @@ class PodcastPlayer extends React.Component<*, { playing: boolean }> {
                     value={photoCredit}
                     placeholder={editing ? 'Photo credit' : ''}
                     onChange={v => updatePodcast(`${id}`, { photoCredit: v })}
+                    onEdit={onBeginEditing}
+                    onCancel={onFinishEditing}
+                    onConfirm={onFinishEditing}
                   />
                 </cite>
               </div>
@@ -152,6 +155,9 @@ class PodcastPlayer extends React.Component<*, { playing: boolean }> {
                     disabled={!editing}
                     value={title}
                     onChange={v => updatePodcast(`${id}`, { title: v })}
+                    onEdit={onBeginEditing}
+                    onCancel={onFinishEditing}
+                    onConfirm={onFinishEditing}
                   />
                 </h1>
 
@@ -159,6 +165,8 @@ class PodcastPlayer extends React.Component<*, { playing: boolean }> {
                   canEdit={editing}
                   credits={creditsList}
                   onChange={v => updatePodcast(`${id}`, { creditsList: v })}
+                  onStartEditing={onBeginEditing}
+                  onFinishEditing={onFinishEditing}
                 />
               </div>
 

--- a/app/javascript/redux/actions/editing.js
+++ b/app/javascript/redux/actions/editing.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import { displayToast } from 'redux/actions'
+import { displayToast, reloadLocks } from 'redux/actions'
 
 import { Intent } from '@blueprintjs/core'
 import { EditorState, convertToRaw } from 'draft-js'
@@ -24,6 +24,7 @@ export function toggleEditing (): ThunkAction {
       )
     }
 
+    dispatch(reloadLocks())
     dispatch({ type: 'TOGGLE_EDITING' })
   }
 }

--- a/app/javascript/redux/actions/editing.js
+++ b/app/javascript/redux/actions/editing.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import { displayToast, reloadLocks } from 'redux/actions'
+import { deleteEnqueuedLocks, displayToast, reloadLocks } from 'redux/actions'
 
 import { Intent } from '@blueprintjs/core'
 import { EditorState, convertToRaw } from 'draft-js'
@@ -51,6 +51,8 @@ function silentlySave (): ThunkAction {
         state
       )
     })
+
+    dispatch(deleteEnqueuedLocks())
 
     dispatch(clearUnsaved())
   }

--- a/app/javascript/redux/actions/editing.js
+++ b/app/javascript/redux/actions/editing.js
@@ -45,16 +45,19 @@ export function saveChanges (): ThunkAction {
 function silentlySave (): ThunkAction {
   return (dispatch: Dispatch, getState: GetState) => {
     const state = getState()
-    Object.keys(state.edit.unsavedChanges).forEach(endpoint => {
-      saveModel(
-        endpoint === 'caseData' ? `cases/${state.caseData.slug}` : endpoint,
-        state
-      )
-    })
+    const unsavedChanges = Object.keys(state.edit.unsavedChanges)
+
+    if (unsavedChanges.length > 0) {
+      unsavedChanges.forEach(endpoint => {
+        saveModel(
+          endpoint === 'caseData' ? `cases/${state.caseData.slug}` : endpoint,
+          state
+        )
+      })
+      dispatch(clearUnsaved())
+    }
 
     dispatch(deleteEnqueuedLocks())
-
-    dispatch(clearUnsaved())
   }
 }
 

--- a/app/javascript/redux/actions/editsChannel.js
+++ b/app/javascript/redux/actions/editsChannel.js
@@ -90,7 +90,7 @@ export function subscribeToEditsChannel (): A.ThunkAction {
       { channel: 'EditsChannel', case_slug: slug },
       {
         received: ({ type, watchable, editor_session_id: editorSessionId }) => {
-          if (watchable.type !== 'Lock' && editorSessionId === sessionId()) {
+          if (editorSessionId === sessionId()) {
             return
           }
 

--- a/app/javascript/redux/actions/editsChannel.js
+++ b/app/javascript/redux/actions/editsChannel.js
@@ -68,6 +68,15 @@ function mapBroadcastToAction (type, watchable) {
           return A.removePodcast(watchable.param)
       }
       break
+
+    case 'Lock':
+      switch (type) {
+        case 'create':
+          return A.addLock(watchable)
+        case 'destroy':
+          return A.removeLock(watchable.param)
+      }
+      break
   }
 }
 
@@ -81,7 +90,9 @@ export function subscribeToEditsChannel (): A.ThunkAction {
       { channel: 'EditsChannel', case_slug: slug },
       {
         received: ({ type, watchable, editor_session_id: editorSessionId }) => {
-          if (editorSessionId === sessionId()) return
+          if (watchable.type !== 'Lock' && editorSessionId === sessionId()) {
+            return
+          }
 
           dispatch((mapBroadcastToAction(type, watchable): any))
         },

--- a/app/javascript/redux/actions/index.js
+++ b/app/javascript/redux/actions/index.js
@@ -80,7 +80,9 @@ export type Action =
   | EditingActions.ToggleEditingAction
   | LockActions.SetLocksAction
   | LockActions.AddLockAction
+  | LockActions.EnqueueLockForDeletionAction
   | LockActions.RemoveLockAction
+  | LockActions.RemoveLockFromDeletionQueueAction
   | PageActions.AddPageAction
   | PageActions.UpdatePageAction
   | PodcastActions.AddPodcastAction

--- a/app/javascript/redux/actions/index.js
+++ b/app/javascript/redux/actions/index.js
@@ -78,6 +78,7 @@ export type Action =
   | EdgenoteActions.UpdateEdgenoteAction
   | EditingActions.ClearUnsavedAction
   | EditingActions.ToggleEditingAction
+  | LockActions.SetLocksAction
   | LockActions.AddLockAction
   | LockActions.RemoveLockAction
   | PageActions.AddPageAction

--- a/app/javascript/redux/actions/index.js
+++ b/app/javascript/redux/actions/index.js
@@ -13,6 +13,7 @@ import * as CommentThreadActions from './commentThread.js'
 import * as CommunityActions from './community.js'
 import * as EdgenoteActions from './edgenote.js'
 import * as EditingActions from './editing.js'
+import * as LockActions from './lock.js'
 import * as PageActions from './page.js'
 import * as PodcastActions from './podcast.js'
 import * as QuizActions from './quiz.js'
@@ -30,6 +31,7 @@ export * from './community.js'
 export * from './edgenote.js'
 export * from './editing.js'
 export * from './editsChannel.js'
+export * from './lock.js'
 export * from './page.js'
 export * from './podcast.js'
 export * from './quiz.js'
@@ -76,6 +78,8 @@ export type Action =
   | EdgenoteActions.UpdateEdgenoteAction
   | EditingActions.ClearUnsavedAction
   | EditingActions.ToggleEditingAction
+  | LockActions.AddLockAction
+  | LockActions.RemoveLockAction
   | PageActions.AddPageAction
   | PageActions.UpdatePageAction
   | PodcastActions.AddPodcastAction

--- a/app/javascript/redux/actions/lock.js
+++ b/app/javascript/redux/actions/lock.js
@@ -47,10 +47,17 @@ export type EnqueueLockForDeletionAction = {
 export function enqueueLockForDeletion (
   type: string,
   param: string
-): EnqueueLockForDeletionAction {
-  return {
-    type: 'ENQUEUE_LOCK_FOR_DELETION',
-    gid: lockableGID({ type, param }),
+): ThunkAction {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const gid = lockableGID({ type, param })
+    const state = getState()
+    state.locks[gid] &&
+      state.caseData.reader &&
+      state.locks[gid].reader.param === `${state.caseData.reader.id}` &&
+      dispatch({
+        type: 'ENQUEUE_LOCK_FOR_DELETION',
+        gid,
+      })
   }
 }
 

--- a/app/javascript/redux/actions/lock.js
+++ b/app/javascript/redux/actions/lock.js
@@ -83,7 +83,7 @@ export function deleteEnqueuedLocks (): ThunkAction {
 
     locksToDelete.forEach(gid => {
       const lock = state.locks[gid]
-      if (lock.reader.param !== reader.id) {
+      if (lock.reader.param === `${reader.id}`) {
         const [type, param] = gid.split('/')
         dispatch(deleteLock(type, param))
       }

--- a/app/javascript/redux/actions/lock.js
+++ b/app/javascript/redux/actions/lock.js
@@ -1,0 +1,15 @@
+/**
+ * @flow
+ */
+
+import type { Lock } from 'redux/state'
+
+export type AddLockAction = { type: 'ADD_LOCK', data: Lock }
+export function addLock (data: Lock): AddLockAction {
+  return { type: 'ADD_LOCK', data }
+}
+
+export type RemoveLockAction = { type: 'REMOVE_LOCK', param: string }
+export function removeLock (param: string): RemoveLockAction {
+  return { type: 'REMOVE_LOCK', param }
+}

--- a/app/javascript/redux/actions/lock.js
+++ b/app/javascript/redux/actions/lock.js
@@ -26,7 +26,10 @@ export function createLock (
 ): ThunkAction {
   return (dispatch: Dispatch, getState: GetState) => {
     const extantLock = getState().locks[`${lockableType}/${lockableParam}`]
-    if (extantLock) return
+    if (extantLock) {
+      dispatch(removeLockFromDeletionQueue(lockableType, lockableParam))
+      return
+    }
 
     Orchard.graft(`locks`, { lock: { lockableType, lockableParam }}).then(
       (lock: Lock) => dispatch(addLock(lock))
@@ -37,6 +40,20 @@ export function createLock (
 export type AddLockAction = { type: 'ADD_LOCK', data: Lock }
 export function addLock (data: Lock): AddLockAction {
   return { type: 'ADD_LOCK', data }
+}
+
+export type EnqueueLockForDeletionAction = {
+  type: 'ENQUEUE_LOCK_FOR_DELETION',
+  gid: string,
+}
+export function enqueueLockForDeletion (
+  lockableType: string,
+  lockableParam: string
+): EnqueueLockForDeletionAction {
+  return {
+    type: 'ENQUEUE_LOCK_FOR_DELETION',
+    gid: `${lockableType}/${lockableParam}`,
+  }
 }
 
 export function deleteLock (
@@ -55,4 +72,18 @@ export function deleteLock (
 export type RemoveLockAction = { type: 'REMOVE_LOCK', param: string }
 export function removeLock (param: string): RemoveLockAction {
   return { type: 'REMOVE_LOCK', param }
+}
+
+export type RemoveLockFromDeletionQueueAction = {
+  type: 'REMOVE_LOCK_FROM_DELETION_QUEUE',
+  gid: string,
+}
+export function removeLockFromDeletionQueue (
+  lockableType: string,
+  lockableParam: string
+): RemoveLockFromDeletionQueueAction {
+  return {
+    type: 'REMOVE_LOCK_FROM_DELETION_QUEUE',
+    gid: `${lockableType}/${lockableParam}`,
+  }
 }

--- a/app/javascript/redux/actions/lock.js
+++ b/app/javascript/redux/actions/lock.js
@@ -2,7 +2,23 @@
  * @flow
  */
 
+import { Orchard } from 'shared/orchard'
+
 import type { Lock } from 'redux/state'
+import type { Dispatch, GetState, ThunkAction } from 'redux/actions'
+
+export function reloadLocks (): ThunkAction {
+  return (dispatch: Dispatch, getState: GetState) => {
+    Orchard.harvest(`cases/${getState().caseData.slug}/locks`).then(locks =>
+      dispatch(setLocks(locks))
+    )
+  }
+}
+
+export type SetLocksAction = { type: 'SET_LOCKS', data: Lock[] }
+function setLocks (data: Lock[]): SetLocksAction {
+  return { type: 'SET_LOCKS', data }
+}
 
 export type AddLockAction = { type: 'ADD_LOCK', data: Lock }
 export function addLock (data: Lock): AddLockAction {

--- a/app/javascript/redux/actions/lock.js
+++ b/app/javascript/redux/actions/lock.js
@@ -39,6 +39,19 @@ export function addLock (data: Lock): AddLockAction {
   return { type: 'ADD_LOCK', data }
 }
 
+export function deleteLock (
+  lockableType: string,
+  lockableParam: string
+): ThunkAction {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const lock = getState().locks[`${lockableType}/${lockableParam}`]
+    if (!lock) return
+
+    const { param } = lock
+    Orchard.prune(`locks/${param}`).then(() => dispatch(removeLock(param)))
+  }
+}
+
 export type RemoveLockAction = { type: 'REMOVE_LOCK', param: string }
 export function removeLock (param: string): RemoveLockAction {
   return { type: 'REMOVE_LOCK', param }

--- a/app/javascript/redux/actions/lock.js
+++ b/app/javascript/redux/actions/lock.js
@@ -20,6 +20,20 @@ function setLocks (data: Lock[]): SetLocksAction {
   return { type: 'SET_LOCKS', data }
 }
 
+export function createLock (
+  lockableType: string,
+  lockableParam: string
+): ThunkAction {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const extantLock = getState().locks[`${lockableType}/${lockableParam}`]
+    if (extantLock) return
+
+    Orchard.graft(`locks`, { lock: { lockableType, lockableParam }}).then(
+      (lock: Lock) => dispatch(addLock(lock))
+    )
+  }
+}
+
 export type AddLockAction = { type: 'ADD_LOCK', data: Lock }
 export function addLock (data: Lock): AddLockAction {
   return { type: 'ADD_LOCK', data }

--- a/app/javascript/redux/reducers/edit.js
+++ b/app/javascript/redux/reducers/edit.js
@@ -13,6 +13,8 @@ import type {
   UpdatePodcastAction,
   UpdateActivityAction,
   UpdateEdgenoteAction,
+  EnqueueLockForDeletionAction,
+  RemoveLockFromDeletionQueueAction,
 } from 'redux/actions'
 
 type Action =
@@ -24,6 +26,8 @@ type Action =
   | UpdatePodcastAction
   | UpdateActivityAction
   | UpdateEdgenoteAction
+  | EnqueueLockForDeletionAction
+  | RemoveLockFromDeletionQueueAction
 
 function edit (state: ?EditState, action: Action): EditState {
   if (state == null) {
@@ -32,6 +36,7 @@ function edit (state: ?EditState, action: Action): EditState {
       possible: !!reader.canUpdateCase,
       inProgress: false,
       changed: false,
+      locksToDelete: [],
       unsavedChanges: {
         // Using this like a Set
         // [`${modelName}/${modelId}` || "caseData"]: true,
@@ -117,6 +122,20 @@ function edit (state: ?EditState, action: Action): EditState {
           [`edgenotes/${action.slug}`]: true,
         },
       }
+
+    case 'ENQUEUE_LOCK_FOR_DELETION':
+      return {
+        ...state,
+        locksToDelete: [...state.locksToDelete, action.gid],
+      }
+
+    case 'REMOVE_LOCK_FROM_DELETION_QUEUE': {
+      const { gid } = action
+      return {
+        ...state,
+        locksToDelete: state.locksToDelete.filter(toDelete => toDelete !== gid),
+      }
+    }
 
     default:
       return state

--- a/app/javascript/redux/reducers/index.js
+++ b/app/javascript/redux/reducers/index.js
@@ -5,33 +5,35 @@
 
 import { combineReducers } from 'redux'
 
+import activitiesById from './activitiesById'
+import cardsById from './cards'
 import caseData from './caseData'
+import commentsById from './commentsById'
+import commentThreadsById from './commentThreadsById'
+import communities from './communities'
 import edgenotesBySlug from './edgenotesBySlug'
+import edit from './edit'
+import locks from './locks'
 import pagesById from './pagesById'
 import podcastsById from './podcastsById'
-import activitiesById from './activitiesById'
-import commentThreadsById from './commentThreadsById'
-import commentsById from './commentsById'
-import communities from './communities'
-import cardsById from './cards'
 import quiz from './quiz'
-import edit from './edit'
 import statistics from './statistics'
 import ui from './ui'
 
 const state = {
-  caseData,
-  edgenotesBySlug,
-  pagesById,
-  podcastsById,
   activitiesById,
   cardsById,
-  commentThreadsById,
+  caseData,
   commentsById,
+  commentThreadsById,
   communities,
-  statistics,
-  quiz,
+  edgenotesBySlug,
   edit,
+  locks,
+  pagesById,
+  podcastsById,
+  quiz,
+  statistics,
   ui,
 }
 

--- a/app/javascript/redux/reducers/locks.js
+++ b/app/javascript/redux/reducers/locks.js
@@ -1,0 +1,32 @@
+/**
+ * @providesModule locks
+ * @flow
+ */
+
+import { reject } from 'ramda'
+
+import type { LocksState, Lock } from 'redux/state'
+import type { AddLockAction, RemoveLockAction } from 'redux/actions'
+type Action = AddLockAction | RemoveLockAction
+
+export default function locks (state: LocksState = {}, action: Action) {
+  switch (action.type) {
+    case 'ADD_LOCK':
+      return {
+        ...state,
+        [gid(action.data.lockable)]: action.data,
+      }
+
+    case 'REMOVE_LOCK': {
+      const { param } = action
+      return reject((lock: Lock) => lock.param === param, state)
+    }
+
+    default:
+      return state
+  }
+}
+
+function gid (lockable) {
+  return `${lockable.type}/${lockable.param}`
+}

--- a/app/javascript/redux/reducers/locks.js
+++ b/app/javascript/redux/reducers/locks.js
@@ -6,11 +6,23 @@
 import { reject } from 'ramda'
 
 import type { LocksState, Lock } from 'redux/state'
-import type { AddLockAction, RemoveLockAction } from 'redux/actions'
-type Action = AddLockAction | RemoveLockAction
+import type {
+  SetLocksAction,
+  AddLockAction,
+  RemoveLockAction,
+} from 'redux/actions'
+type Action = SetLocksAction | AddLockAction | RemoveLockAction
 
 export default function locks (state: LocksState = {}, action: Action) {
   switch (action.type) {
+    case 'SET_LOCKS': {
+      const { data } = action
+      return data.reduce((object, lock) => {
+        object[gid(lock.lockable)] = lock
+        return object
+      }, {})
+    }
+
     case 'ADD_LOCK':
       return {
         ...state,

--- a/app/javascript/redux/reducers/locks.js
+++ b/app/javascript/redux/reducers/locks.js
@@ -18,7 +18,7 @@ export default function locks (state: LocksState = {}, action: Action) {
     case 'SET_LOCKS': {
       const { data } = action
       return data.reduce((object, lock) => {
-        object[gid(lock.lockable)] = lock
+        object[lockableGID(lock.lockable)] = lock
         return object
       }, {})
     }
@@ -26,7 +26,7 @@ export default function locks (state: LocksState = {}, action: Action) {
     case 'ADD_LOCK':
       return {
         ...state,
-        [gid(action.data.lockable)]: action.data,
+        [lockableGID(action.data.lockable)]: action.data,
       }
 
     case 'REMOVE_LOCK': {
@@ -39,6 +39,6 @@ export default function locks (state: LocksState = {}, action: Action) {
   }
 }
 
-function gid (lockable) {
+export function lockableGID (lockable: { type: string, param: string }) {
   return `${lockable.type}/${lockable.param}`
 }

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -281,6 +281,7 @@ export type Lock = {
     hashKey: string,
     imageUrl: string,
     name: string,
+    param: string,
   },
 }
 

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -54,6 +54,7 @@ export type EdgenotesState = {
 export type EditState = {
   changed: boolean,
   inProgress: boolean,
+  locksToDelete: string[],
   possible: boolean,
   unsavedChanges: {
     [modelSlashId: string]: boolean,

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -11,18 +11,19 @@ export type ExtractReturn<F> = _ExtractReturn<*, F>
 
 // Redux state
 export type State = {
-  caseData: CaseDataState,
-  edgenotesBySlug: EdgenotesState,
-  pagesById: PagesState,
-  podcastsById: PodcastsState,
   activitiesById: ActivitiesState,
   cardsById: CardsState,
-  commentThreadsById: CommentThreadsState,
+  caseData: CaseDataState,
   commentsById: CommentsState,
+  commentThreadsById: CommentThreadsState,
   communities: CommunitiesState[],
-  statistics: StatisticsState,
-  quiz: QuizState,
+  edgenotesBySlug: EdgenotesState,
   edit: EditState,
+  locks: LocksState,
+  pagesById: PagesState,
+  podcastsById: PodcastsState,
+  quiz: QuizState,
+  statistics: StatisticsState,
   ui: UIState,
 }
 
@@ -57,6 +58,10 @@ export type EditState = {
   unsavedChanges: {
     [modelSlashId: string]: boolean,
   },
+}
+
+export type LocksState = {
+  [gid: string]: Lock,
 }
 
 export type PagesState = {
@@ -265,6 +270,18 @@ export type LinkExpansionVisibility = {
   noEmbed?: boolean,
   noDescription?: boolean,
   noImage?: boolean,
+}
+
+export type Lock = {
+  caseSlug: string,
+  createdAt: Date,
+  lockable: { type: string, table: string, param: string },
+  param: string,
+  reader: {
+    hashKey: string,
+    imageUrl: string,
+    name: string,
+  },
 }
 
 export type Notification = {

--- a/app/javascript/shared/Identicon.jsx
+++ b/app/javascript/shared/Identicon.jsx
@@ -52,10 +52,12 @@ const Identicon = ({
   reader,
   width = 36,
   presentational,
+  className,
 }: {
   reader: { imageUrl: ?string, hashKey: string, name: string },
   width?: number,
   presentational?: boolean,
+  className?: string,
 }) => (
   <IdenticonDiv
     presentational={presentational}
@@ -63,6 +65,7 @@ const Identicon = ({
     image={reader.imageUrl}
     hashKey={reader.hashKey}
     text={reader.name}
+    className={className}
   />
 )
 export default Identicon

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -4,31 +4,43 @@
  */
 
 import * as React from 'react'
+import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { FormattedRelative, FormattedMessage } from 'react-intl'
 
-const reader = {
-  type: 'Reader',
-  table: 'readers',
-  param: '2',
-  imageUrl:
-    '/rails/active_storage/variants/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZUk9IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4a867c77a651735ac13737582dcbe8e7f4a4e439/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9PZEdoMWJXSnVZV2xzU1NJTk1UQXdlREV3TUY0R09nWkZWQT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--76ab9de1d2e504c8e6bde0b7b9990f1713e4f7a8/griffin.jpeg',
-  hashKey: 'f8b92ac580f078295d054b6df47f41eabd62ed763a00950152d8bc1da80d8743',
-  name: 'Cameron Bothner',
+import type { State, Lock as LockT } from 'redux/state'
+
+type OwnProps = {
+  param: string,
+  type: string,
 }
-const time = new Date('2018-05-23T16:26:07.639Z')
+
+function mapStateToProps (
+  { caseData, edit, locks }: State,
+  { type, param }: OwnProps
+) {
+  const { reader } = caseData
+  const lock = locks[`${type}/${param}`]
+  return {
+    lock,
+    locked: !!reader && !!lock && lock.reader.param !== `${reader.id}`,
+    visible: edit.inProgress,
+  }
+}
 
 type Props = {
   children: () => React.Node,
-  locked?: boolean,
-  visible?: boolean,
+  lock: ?LockT,
+  locked: boolean,
+  visible: boolean,
 }
 
-const Lock = ({ children, locked, visible }: Props) => (
+const Lock = ({ children, lock, locked, visible }: Props) => (
   <React.Fragment>
     {children()}
-    {locked &&
-      visible && (
+    {visible &&
+      locked &&
+      lock && (
       <React.Fragment>
         <LockOverlay />
         <LockDetails>
@@ -40,8 +52,8 @@ const Lock = ({ children, locked, visible }: Props) => (
               <FormattedMessage
                 id="locks.lock.details"
                 values={{
-                  name: reader.name,
-                  someTimeAgo: <FormattedRelative value={time} />,
+                  name: lock.reader.name,
+                  someTimeAgo: <FormattedRelative value={lock.createdAt} />,
                 }}
               />
             </p>
@@ -55,7 +67,7 @@ const Lock = ({ children, locked, visible }: Props) => (
   </React.Fragment>
 )
 
-export default Lock
+export default connect(mapStateToProps)(Lock)
 
 /**
  * STYLED COMPONENTS

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -1,0 +1,116 @@
+/**
+ * @providesModule Lock
+ * @flow
+ */
+
+import * as React from 'react'
+import styled from 'styled-components'
+import { FormattedRelative, FormattedMessage } from 'react-intl'
+
+const reader = {
+  type: 'Reader',
+  table: 'readers',
+  param: '2',
+  imageUrl:
+    '/rails/active_storage/variants/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZUk9IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4a867c77a651735ac13737582dcbe8e7f4a4e439/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9PZEdoMWJXSnVZV2xzU1NJTk1UQXdlREV3TUY0R09nWkZWQT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--76ab9de1d2e504c8e6bde0b7b9990f1713e4f7a8/griffin.jpeg',
+  hashKey: 'f8b92ac580f078295d054b6df47f41eabd62ed763a00950152d8bc1da80d8743',
+  name: 'Cameron Bothner',
+}
+const time = new Date('2018-05-23T16:26:07.639Z')
+
+type Props = {
+  children: () => React.Node,
+  locked?: boolean,
+  visible?: boolean,
+}
+
+const Lock = ({ children, locked, visible }: Props) => (
+  <React.Fragment>
+    {children()}
+    {locked &&
+      visible && (
+      <React.Fragment>
+        <LockOverlay />
+        <LockDetails>
+          <div className="pt-callout pt-intent-danger pt-icon-lock">
+            <h5 className="pt-callout-title">
+              <FormattedMessage id="locks.lock.thisSectionIsLocked" />
+            </h5>
+            <p>
+              <FormattedMessage
+                id="locks.lock.details"
+                values={{
+                  name: reader.name,
+                  someTimeAgo: <FormattedRelative value={time} />,
+                }}
+              />
+            </p>
+            <button className="pt-button pt-intent-danger">
+              <FormattedMessage id="locks.destroy.editAnyway" />
+            </button>
+          </div>
+        </LockDetails>
+      </React.Fragment>
+    )}
+  </React.Fragment>
+)
+
+export default Lock
+
+/**
+ * STYLED COMPONENTS
+ */
+
+const LockOverlay = styled.div`
+  background-color: hsl(208, 30%, 23%);
+  border: 1px solid black;
+  border-radius: 2pt;
+  height: calc(100% + 16px);
+  left: -8px;
+  mix-blend-mode: hard-light;
+  position: absolute;
+  top: -8px;
+  width: calc(100% + 16px);
+  z-index: 10;
+`
+
+const LockDetails = styled.div.attrs({ className: 'pt-card pt-elevation-4' })`
+  background-color: #fdfdfa !important;
+  color: #01182e !important;
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: 0.2s ease-out opacity 0.1s;
+  width: 300px;
+  z-index: 11;
+
+  ${LockOverlay}:hover + &,
+  &:hover {
+    opacity: 1;
+  }
+
+  .pt-callout.pt-intent-danger[class*='pt-icon-']::before,
+  .pt-callout.pt-intent-danger h5 {
+    color: #c23030 !important;
+  }
+
+  h5 {
+    font-family: ${p => p.theme.sansFont};
+    line-height: 20px;
+    margin: 0 0 5px 0;
+  }
+
+  p {
+    font-family: ${p => p.theme.sansFont};
+    font-weight: 400;
+    line-height: 1.4;
+    margin: 0 0 0.65em;
+  }
+
+  button {
+    box-shadow: inset 0 0 0 1px rgba(16, 22, 26, 0.4),
+      inset 0 -1px 0 rgba(16, 22, 26, 0.2) !important;
+  }
+`

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { FormattedRelative, FormattedMessage } from 'react-intl'
 
-import { createLock } from 'redux/actions'
+import { createLock, deleteLock } from 'redux/actions'
 
 import type { Dispatch } from 'redux/actions'
 import type { State, Lock as LockT } from 'redux/state'
@@ -36,6 +36,7 @@ function mapDispatchToProps (dispatch: Dispatch, { type, param }: OwnProps) {
     onBeginEditing: () => {
       dispatch(createLock(type, param))
     },
+    onEditAnyway: () => dispatch(deleteLock(type, param)),
   }
 }
 
@@ -47,10 +48,18 @@ type Props = {
   children: LockableProps => React.Node,
   lock: ?LockT,
   locked: boolean,
+  onEditAnyway: () => mixed,
   visible: boolean,
 } & LockableProps
 
-const Lock = ({ children, lock, locked, onBeginEditing, visible }: Props) => (
+const Lock = ({
+  children,
+  lock,
+  locked,
+  onBeginEditing,
+  onEditAnyway,
+  visible,
+}: Props) => (
   <React.Fragment>
     {children({ onBeginEditing })}
     {visible &&
@@ -72,7 +81,10 @@ const Lock = ({ children, lock, locked, onBeginEditing, visible }: Props) => (
                 }}
               />
             </p>
-            <button className="pt-button pt-intent-danger">
+            <button
+              className="pt-button pt-intent-danger"
+              onClick={onEditAnyway}
+            >
               <FormattedMessage id="locks.destroy.editAnyway" />
             </button>
           </div>

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { FormattedRelative, FormattedMessage } from 'react-intl'
 
-import { createLock, deleteLock } from 'redux/actions'
+import { createLock, deleteLock, enqueueLockForDeletion } from 'redux/actions'
 
 import type { Dispatch } from 'redux/actions'
 import type { State, Lock as LockT } from 'redux/state'
@@ -37,11 +37,15 @@ function mapDispatchToProps (dispatch: Dispatch, { type, param }: OwnProps) {
       dispatch(createLock(type, param))
     },
     onEditAnyway: () => dispatch(deleteLock(type, param)),
+    onFinishEditing: () => {
+      dispatch(enqueueLockForDeletion(type, param))
+    },
   }
 }
 
 type LockableProps = {
   onBeginEditing: () => void,
+  onFinishEditing: () => void,
 }
 
 type Props = {
@@ -58,10 +62,11 @@ const Lock = ({
   locked,
   onBeginEditing,
   onEditAnyway,
+  onFinishEditing,
   visible,
 }: Props) => (
   <React.Fragment>
-    {children({ onBeginEditing })}
+    {children({ onBeginEditing, onFinishEditing })}
     {visible &&
       locked &&
       lock && (

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -8,6 +8,9 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { FormattedRelative, FormattedMessage } from 'react-intl'
 
+import { createLock } from 'redux/actions'
+
+import type { Dispatch } from 'redux/actions'
 import type { State, Lock as LockT } from 'redux/state'
 
 type OwnProps = {
@@ -28,16 +31,28 @@ function mapStateToProps (
   }
 }
 
+function mapDispatchToProps (dispatch: Dispatch, { type, param }: OwnProps) {
+  return {
+    onBeginEditing: () => {
+      dispatch(createLock(type, param))
+    },
+  }
+}
+
+type LockableProps = {
+  onBeginEditing: () => void,
+}
+
 type Props = {
-  children: () => React.Node,
+  children: LockableProps => React.Node,
   lock: ?LockT,
   locked: boolean,
   visible: boolean,
-}
+} & LockableProps
 
-const Lock = ({ children, lock, locked, visible }: Props) => (
+const Lock = ({ children, lock, locked, onBeginEditing, visible }: Props) => (
   <React.Fragment>
-    {children()}
+    {children({ onBeginEditing })}
     {visible &&
       locked &&
       lock && (
@@ -67,7 +82,7 @@ const Lock = ({ children, lock, locked, visible }: Props) => (
   </React.Fragment>
 )
 
-export default connect(mapStateToProps)(Lock)
+export default connect(mapStateToProps, mapDispatchToProps)(Lock)
 
 /**
  * STYLED COMPONENTS

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -44,6 +44,7 @@ function mapDispatchToProps (dispatch: Dispatch, { type, param }: OwnProps) {
 }
 
 type LockableProps = {
+  locked: boolean,
   onBeginEditing: () => void,
   onFinishEditing: () => void,
 }
@@ -51,7 +52,6 @@ type LockableProps = {
 type Props = {
   children: LockableProps => React.Node,
   lock: ?LockT,
-  locked: boolean,
   onEditAnyway: () => mixed,
   visible: boolean,
 } & LockableProps
@@ -66,7 +66,7 @@ const Lock = ({
   visible,
 }: Props) => (
   <React.Fragment>
-    {children({ onBeginEditing, onFinishEditing })}
+    {children({ locked, onBeginEditing, onFinishEditing })}
     {visible &&
       locked &&
       lock && (

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -111,6 +111,7 @@ const LockOverlay = styled.div`
   border-radius: 2pt;
   height: calc(100% + 16px);
   left: -8px;
+  margin: 0;
   mix-blend-mode: hard-light;
   position: absolute;
   top: -8px;

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -7,6 +7,7 @@
 # @attr pdf_url [Translated<String>]
 class Activity < ApplicationRecord
   include Element
+  include Lockable
   include Mobility
 
   translates :title, :description, :pdf_url, fallbacks: true

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -11,6 +11,7 @@
 # @attr raw_content [Translated<RawDraftContentState>] the card’s content, to be
 #   used with Draft.js in React
 class Card < ApplicationRecord
+  include Lockable
   include Mobility
   include Trackable
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -127,6 +127,7 @@ class Case < ApplicationRecord
     super
   end
 
+  # This is to conform with Lockable
   def case
     self
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -43,6 +43,7 @@ class Case < ApplicationRecord
 
   belongs_to :library, optional: true
 
+  has_many :active_locks, class_name: 'Lock'
   has_many :cards
   has_many :case_elements, -> { order position: :asc }, dependent: :destroy
   has_many :comment_threads, dependent: :destroy

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -29,6 +29,7 @@
 # @attr commentable [Boolean] whether or not forums are enabled on the case
 class Case < ApplicationRecord
   include Comparable
+  include Lockable
   include Mobility
   extend FriendlyId
 

--- a/app/models/concerns/element.rb
+++ b/app/models/concerns/element.rb
@@ -11,6 +11,12 @@ module Element
     after_save -> { case_element.touch }
   end
 
+  class_methods do
+    def policy_class
+      ElementPolicy
+    end
+  end
+
   # @return [Case]
   def case
     case_element.case

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -11,9 +11,9 @@ module Lockable
   end
 
   def lock_by(reader)
-    transaction do
-      create_lock! reader: reader
-    end
+    create_lock! reader: reader
+  rescue ActiveRecord::RecordNotUnique
+    nil
   end
 
   def locked?

--- a/app/models/concerns/lockable.rb
+++ b/app/models/concerns/lockable.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# An element that supports multiple editors by requiring a user to take a lock
+# before editing. This way, others can told that the element is being edited
+# and can be prevented from making their edits.
+module Lockable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :lock, as: :lockable, dependent: :destroy
+  end
+
+  def lock_by(reader)
+    transaction do
+      create_lock! reader: reader
+    end
+  end
+
+  def locked?
+    lock.present?
+  end
+
+  def locked_by?(reader)
+    locked? && lock.reader == reader
+  end
+
+  def unlock
+    update! lock: nil
+  end
+end

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -21,9 +21,11 @@ class Edgenote < ApplicationRecord
   include Lockable
   include Mobility
   include Trackable
+  extend FriendlyId
 
   attribute :format, :string, default: 'aside'
   attribute :style, :integer, default: 1 # :v2
+  friendly_id :slug
   translates :caption, :content, :instructions, :website_url,
              :embed_code, :photo_credit, :pdf_url, :pull_quote, :attribution,
              :call_to_action, fallbacks: true

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -43,6 +43,10 @@ class Edgenote < ApplicationRecord
 
   before_create :ensure_slug_set
 
+  def self.policy_class
+    ElementPolicy
+  end
+
   # The name of the corresponding {Ahoy::Event}s
   # @see Trackable#event_name
   def event_name

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -18,6 +18,7 @@
 # @attr alt_text [String] @todo translate this
 # @attr website_url [Translated<String>]
 class Edgenote < ApplicationRecord
+  include Lockable
   include Mobility
   include Trackable
 

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -8,4 +8,12 @@ class Lock < ApplicationRecord
   belongs_to :case
 
   validates :lockable_type, only_polymorphic: true
+
+  before_validation :set_case_from_lockable, unless: -> { self.case.present? }
+
+  private
+
+  def set_case_from_lockable
+    self.case = lockable.case
+  end
 end

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -6,4 +6,6 @@ class Lock < ApplicationRecord
   belongs_to :lockable, polymorphic: true
   belongs_to :reader
   belongs_to :case
+
+  validates :lockable_type, only_polymorphic: true
 end

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -5,7 +5,7 @@
 class Lock < ApplicationRecord
   belongs_to :lockable, polymorphic: true
   belongs_to :reader
-  belongs_to :case
+  belongs_to :case, inverse_of: :active_locks
 
   validates :lockable_type, only_polymorphic: true
 

--- a/app/models/lock.rb
+++ b/app/models/lock.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# A lock prevents a user from editing a model that another user is already
+# editing. A user must take a lock on a model before writing to it.
+class Lock < ApplicationRecord
+  belongs_to :lockable, polymorphic: true
+  belongs_to :reader
+  belongs_to :case
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,6 +5,7 @@
 # @attr title [Translated<String>] the page’s title
 class Page < ApplicationRecord
   include Element
+  include Lockable
   include Mobility
 
   translates :title, fallbacks: true

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -7,6 +7,7 @@
 # @attr photo_credit [String] attribution for the {artwork_url}’s rights holder
 class Podcast < ApplicationRecord
   include Element
+  include Lockable
   include Mobility
   include Trackable
 

--- a/app/policies/card_policy.rb
+++ b/app/policies/card_policy.rb
@@ -1,23 +1,15 @@
 # frozen_string_literal: true
 
 # @see Card
-class CardPolicy < ApplicationPolicy
-  def create?
-    user_can_update_case?
-  end
-
-  def update?
-    user_can_update_case?
-  end
-
+class CardPolicy < ElementPolicy
   def destroy?
     return false unless record.siblings?
-    user_can_update_case?
+    super
   end
 
   private
 
-  def user_can_update_case?
-    Pundit.policy(user, record.element.case).update?
+  def case
+    record.element.case
   end
 end

--- a/app/policies/element_policy.rb
+++ b/app/policies/element_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Elements are creatable, updatable, and destroyable by anyone who can update
+# their case
+class ElementPolicy < ApplicationPolicy
+  def create?
+    user_can_update_case?
+  end
+
+  def update?
+    user_can_update_case?
+  end
+
+  def destroy?
+    user_can_update_case?
+  end
+
+  private
+
+  def user_can_update_case?
+    Pundit.policy(user, send(:case)).update?
+  end
+
+  def case
+    record.case
+  end
+end

--- a/app/serializers/comment_thread_serializer.rb
+++ b/app/serializers/comment_thread_serializer.rb
@@ -6,18 +6,13 @@ class CommentThreadSerializer < ApplicationSerializer
              :comments_count
   attributes :block_index, :start, :length
   attribute(:comment_ids) { object.comments.pluck(:id) }
-  attribute :readers
+
+  has_many :collocutors, key: :readers, serializer: Readers::IdenticonSerializer
 
   delegate :block_index, :start, :length, to: :@range_calculator
 
   def initialize(*props)
     super(*props)
     @range_calculator = CommentThreadRangeCalculator.new object
-  end
-
-  def readers
-    object.collocutors.map do |reader|
-      reader.slice :image_url, :hash_key, :name
-    end
   end
 end

--- a/app/serializers/lock_serializer.rb
+++ b/app/serializers/lock_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# @see Lock
+class LockSerializer < ApplicationSerializer
+  class LockableSerializer < ApplicationSerializer; end
+
+  attributes :created_at
+  attribute(:case_slug) { object.case.slug }
+
+  belongs_to :lockable, serializer: LockableSerializer
+  belongs_to :reader, serializer: Readers::IdenticonSerializer
+end

--- a/app/serializers/readers/identicon_serializer.rb
+++ b/app/serializers/readers/identicon_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Readers
+  # Serialize the bits you need for an identicon
+  class IdenticonSerializer < ApplicationSerializer
+    attributes :image_url, :hash_key, :name
+
+    def initialize(*props)
+      super(*props)
+      self.object = object.decorate
+    end
+  end
+end

--- a/app/validators/only_polymorphic_validator.rb
+++ b/app/validators/only_polymorphic_validator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Ensure that the type column of a model that belongs to a polymorphic role
+# corresponds to a class that fills that role.
+class OnlyPolymorphicValidator < ActiveModel::EachValidator
+  DEFAULT_MESSAGE = 'isn’t a polymorphic type'
+
+  def validate_each(record, attribute, value)
+    role = attribute.to_s.delete_suffix '_type'
+    klass = safe_constantize value
+    singular_association_name = record.class.name.underscore
+
+    return if polymorphic_association? klass, singular_association_name, role
+
+    record.errors[attribute] << (options[:message] || DEFAULT_MESSAGE)
+  end
+
+  private
+
+  def safe_constantize(value)
+    value.constantize
+  rescue NameError
+    nil
+  end
+
+  def polymorphic_association?(klass, association_name, role)
+    association = klass.reflect_on_association association_name
+    association ||= klass.reflect_on_association association_name.pluralize
+    association&.options&.[](:as) == role.to_sym
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -562,6 +562,14 @@ en:
         text: >
           You are receiving this email because you are a user of Gala
           (https://www.learngala.com).
+  locks:
+    destroy:
+      edit_anyway: Edit Anyway
+    lock:
+      details: |
+        {name} is editing this section as of {someTimeAgo}. If you proceed,
+        their changes may be lost.
+      this_section_is_locked: This section is locked.
   magic_link:
     show:
       lets_get_started: Let’s get started!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
 
       resource :enrollment, only: %i[create destroy]
 
+      resources :locks, only: %i[index]
+
       resources :podcasts, only: %i[create]
 
       resources :pages, only: %i[create]
@@ -84,6 +86,8 @@ Rails.application.routes.draw do
     end
 
     resources :libraries, param: :slug, only: %i[show]
+
+    resources :locks, only: %i[create destroy]
 
     resource :magic_link, only: %i[show create]
 

--- a/db/migrate/20180518184926_create_locks.rb
+++ b/db/migrate/20180518184926_create_locks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateLocks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :locks do |t|
+      t.references :lockable, polymorphic: true, index: { unique: true }
+      t.references :reader, foreign_key: true
+      t.references :case, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -863,6 +863,40 @@ ALTER SEQUENCE link_expansion_visibilities_id_seq OWNED BY link_expansion_visibi
 
 
 --
+-- Name: locks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE locks (
+    id bigint NOT NULL,
+    lockable_type character varying,
+    lockable_id bigint,
+    reader_id bigint,
+    case_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: locks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE locks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: locks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE locks_id_seq OWNED BY locks.id;
+
+
+--
 -- Name: managerships; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1420,6 +1454,13 @@ ALTER TABLE ONLY link_expansion_visibilities ALTER COLUMN id SET DEFAULT nextval
 
 
 --
+-- Name: locks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY locks ALTER COLUMN id SET DEFAULT nextval('locks_id_seq'::regclass);
+
+
+--
 -- Name: managerships id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1698,6 +1739,14 @@ ALTER TABLE ONLY link_expansion_visibilities
 
 
 --
+-- Name: locks locks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY locks
+    ADD CONSTRAINT locks_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: managerships managerships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1789,539 +1838,560 @@ ALTER TABLE ONLY visits
 -- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_storage_attachments_on_blob_id ON public.active_storage_attachments USING btree (blob_id);
+CREATE INDEX index_active_storage_attachments_on_blob_id ON active_storage_attachments USING btree (blob_id);
 
 
 --
 -- Name: index_active_storage_attachments_uniqueness; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON public.active_storage_attachments USING btree (record_type, record_id, name, blob_id);
+CREATE UNIQUE INDEX index_active_storage_attachments_uniqueness ON active_storage_attachments USING btree (record_type, record_id, name, blob_id);
 
 
 --
 -- Name: index_active_storage_blobs_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON public.active_storage_blobs USING btree (key);
+CREATE UNIQUE INDEX index_active_storage_blobs_on_key ON active_storage_blobs USING btree (key);
 
 
 --
 -- Name: index_activities_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_activities_on_case_id ON public.activities USING btree (case_id);
+CREATE INDEX index_activities_on_case_id ON activities USING btree (case_id);
 
 
 --
 -- Name: index_ahoy_events_on_name_and_time; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ahoy_events_on_name_and_time ON public.ahoy_events USING btree (name, "time");
+CREATE INDEX index_ahoy_events_on_name_and_time ON ahoy_events USING btree (name, "time");
 
 
 --
 -- Name: index_ahoy_events_on_properties_jsonb_path_ops; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ahoy_events_on_properties_jsonb_path_ops ON public.ahoy_events USING gin (properties jsonb_path_ops);
+CREATE INDEX index_ahoy_events_on_properties_jsonb_path_ops ON ahoy_events USING gin (properties jsonb_path_ops);
 
 
 --
 -- Name: index_ahoy_events_on_user_id_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ahoy_events_on_user_id_and_name ON public.ahoy_events USING btree (user_id, name);
+CREATE INDEX index_ahoy_events_on_user_id_and_name ON ahoy_events USING btree (user_id, name);
 
 
 --
 -- Name: index_ahoy_events_on_visit_id_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ahoy_events_on_visit_id_and_name ON public.ahoy_events USING btree (visit_id, name);
+CREATE INDEX index_ahoy_events_on_visit_id_and_name ON ahoy_events USING btree (visit_id, name);
 
 
 --
 -- Name: index_answers_on_question_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_answers_on_question_id ON public.answers USING btree (question_id);
+CREATE INDEX index_answers_on_question_id ON answers USING btree (question_id);
 
 
 --
 -- Name: index_answers_on_quiz_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_answers_on_quiz_id ON public.answers USING btree (quiz_id);
+CREATE INDEX index_answers_on_quiz_id ON answers USING btree (quiz_id);
 
 
 --
 -- Name: index_answers_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_answers_on_reader_id ON public.answers USING btree (reader_id);
+CREATE INDEX index_answers_on_reader_id ON answers USING btree (reader_id);
 
 
 --
 -- Name: index_answers_on_submission_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_answers_on_submission_id ON public.answers USING btree (submission_id);
+CREATE INDEX index_answers_on_submission_id ON answers USING btree (submission_id);
 
 
 --
 -- Name: index_authentication_strategies_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_authentication_strategies_on_reader_id ON public.authentication_strategies USING btree (reader_id);
+CREATE INDEX index_authentication_strategies_on_reader_id ON authentication_strategies USING btree (reader_id);
 
 
 --
 -- Name: index_authentication_strategies_on_uid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_authentication_strategies_on_uid ON public.authentication_strategies USING btree (uid) WHERE ((provider)::text = 'lti'::text);
+CREATE INDEX index_authentication_strategies_on_uid ON authentication_strategies USING btree (uid) WHERE ((provider)::text = 'lti'::text);
 
 
 --
 -- Name: index_cards_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_cards_on_case_id ON public.cards USING btree (case_id);
+CREATE INDEX index_cards_on_case_id ON cards USING btree (case_id);
 
 
 --
 -- Name: index_cards_on_element_type_and_element_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_cards_on_element_type_and_element_id ON public.cards USING btree (element_type, element_id);
+CREATE INDEX index_cards_on_element_type_and_element_id ON cards USING btree (element_type, element_id);
 
 
 --
 -- Name: index_cards_on_page_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_cards_on_page_id ON public.cards USING btree (page_id);
+CREATE INDEX index_cards_on_page_id ON cards USING btree (page_id);
 
 
 --
 -- Name: index_case_elements_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_case_elements_on_case_id ON public.case_elements USING btree (case_id);
+CREATE INDEX index_case_elements_on_case_id ON case_elements USING btree (case_id);
 
 
 --
 -- Name: index_case_elements_on_element_type_and_element_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_case_elements_on_element_type_and_element_id ON public.case_elements USING btree (element_type, element_id);
+CREATE INDEX index_case_elements_on_element_type_and_element_id ON case_elements USING btree (element_type, element_id);
 
 
 --
 -- Name: index_cases_on_english_full_text; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_cases_on_english_full_text ON public.cases_search_index_en USING gin (document);
+CREATE INDEX index_cases_on_english_full_text ON cases_search_index_en USING gin (document);
 
 
 --
 -- Name: index_cases_on_library_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_cases_on_library_id ON public.cases USING btree (library_id);
+CREATE INDEX index_cases_on_library_id ON cases USING btree (library_id);
 
 
 --
 -- Name: index_cases_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_cases_on_slug ON public.cases USING btree (slug);
+CREATE UNIQUE INDEX index_cases_on_slug ON cases USING btree (slug);
 
 
 --
 -- Name: index_cases_on_tags; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_cases_on_tags ON public.cases USING gin (tags);
+CREATE INDEX index_cases_on_tags ON cases USING gin (tags);
 
 
 --
 -- Name: index_cases_search_index_en; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_cases_search_index_en ON public.cases_search_index_en USING btree (id);
+CREATE UNIQUE INDEX index_cases_search_index_en ON cases_search_index_en USING btree (id);
 
 
 --
 -- Name: index_comment_threads_on_card_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_comment_threads_on_card_id ON public.comment_threads USING btree (card_id);
+CREATE INDEX index_comment_threads_on_card_id ON comment_threads USING btree (card_id);
 
 
 --
 -- Name: index_comment_threads_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_comment_threads_on_case_id ON public.comment_threads USING btree (case_id);
+CREATE INDEX index_comment_threads_on_case_id ON comment_threads USING btree (case_id);
 
 
 --
 -- Name: index_comment_threads_on_forum_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_comment_threads_on_forum_id ON public.comment_threads USING btree (forum_id);
+CREATE INDEX index_comment_threads_on_forum_id ON comment_threads USING btree (forum_id);
 
 
 --
 -- Name: index_comment_threads_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_comment_threads_on_reader_id ON public.comment_threads USING btree (reader_id);
+CREATE INDEX index_comment_threads_on_reader_id ON comment_threads USING btree (reader_id);
 
 
 --
 -- Name: index_comments_on_comment_thread_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_comments_on_comment_thread_id ON public.comments USING btree (comment_thread_id);
+CREATE INDEX index_comments_on_comment_thread_id ON comments USING btree (comment_thread_id);
 
 
 --
 -- Name: index_comments_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_comments_on_reader_id ON public.comments USING btree (reader_id);
+CREATE INDEX index_comments_on_reader_id ON comments USING btree (reader_id);
 
 
 --
 -- Name: index_communities_on_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_communities_on_group_id ON public.communities USING btree (group_id);
+CREATE INDEX index_communities_on_group_id ON communities USING btree (group_id);
 
 
 --
 -- Name: index_communities_on_universal; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_communities_on_universal ON public.communities USING btree (universal);
+CREATE INDEX index_communities_on_universal ON communities USING btree (universal);
 
 
 --
 -- Name: index_deployments_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_deployments_on_case_id ON public.deployments USING btree (case_id);
+CREATE INDEX index_deployments_on_case_id ON deployments USING btree (case_id);
 
 
 --
 -- Name: index_deployments_on_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_deployments_on_group_id ON public.deployments USING btree (group_id);
+CREATE INDEX index_deployments_on_group_id ON deployments USING btree (group_id);
 
 
 --
 -- Name: index_deployments_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_deployments_on_key ON public.deployments USING btree (key);
+CREATE UNIQUE INDEX index_deployments_on_key ON deployments USING btree (key);
 
 
 --
 -- Name: index_deployments_on_quiz_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_deployments_on_quiz_id ON public.deployments USING btree (quiz_id);
+CREATE INDEX index_deployments_on_quiz_id ON deployments USING btree (quiz_id);
 
 
 --
 -- Name: index_edgenotes_on_card_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_edgenotes_on_card_id ON public.edgenotes USING btree (card_id);
+CREATE INDEX index_edgenotes_on_card_id ON edgenotes USING btree (card_id);
 
 
 --
 -- Name: index_edgenotes_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_edgenotes_on_case_id ON public.edgenotes USING btree (case_id);
+CREATE INDEX index_edgenotes_on_case_id ON edgenotes USING btree (case_id);
 
 
 --
 -- Name: index_edgenotes_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_edgenotes_on_slug ON public.edgenotes USING btree (slug);
+CREATE UNIQUE INDEX index_edgenotes_on_slug ON edgenotes USING btree (slug);
 
 
 --
 -- Name: index_editorships_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_editorships_on_case_id ON public.editorships USING btree (case_id);
+CREATE INDEX index_editorships_on_case_id ON editorships USING btree (case_id);
 
 
 --
 -- Name: index_editorships_on_editor_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_editorships_on_editor_id ON public.editorships USING btree (editor_id);
+CREATE INDEX index_editorships_on_editor_id ON editorships USING btree (editor_id);
 
 
 --
 -- Name: index_enrollments_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_enrollments_on_case_id ON public.enrollments USING btree (case_id);
+CREATE INDEX index_enrollments_on_case_id ON enrollments USING btree (case_id);
 
 
 --
 -- Name: index_enrollments_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_enrollments_on_reader_id ON public.enrollments USING btree (reader_id);
+CREATE INDEX index_enrollments_on_reader_id ON enrollments USING btree (reader_id);
 
 
 --
 -- Name: index_forums_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_forums_on_case_id ON public.forums USING btree (case_id);
+CREATE INDEX index_forums_on_case_id ON forums USING btree (case_id);
 
 
 --
 -- Name: index_forums_on_community_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_forums_on_community_id ON public.forums USING btree (community_id);
+CREATE INDEX index_forums_on_community_id ON forums USING btree (community_id);
 
 
 --
 -- Name: index_friendly_id_slugs_on_slug_and_sluggable_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type ON public.friendly_id_slugs USING btree (slug, sluggable_type);
+CREATE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type ON friendly_id_slugs USING btree (slug, sluggable_type);
 
 
 --
 -- Name: index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope ON public.friendly_id_slugs USING btree (slug, sluggable_type, scope);
+CREATE UNIQUE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope ON friendly_id_slugs USING btree (slug, sluggable_type, scope);
 
 
 --
 -- Name: index_friendly_id_slugs_on_sluggable_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_friendly_id_slugs_on_sluggable_id ON public.friendly_id_slugs USING btree (sluggable_id);
+CREATE INDEX index_friendly_id_slugs_on_sluggable_id ON friendly_id_slugs USING btree (sluggable_id);
 
 
 --
 -- Name: index_friendly_id_slugs_on_sluggable_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_friendly_id_slugs_on_sluggable_type ON public.friendly_id_slugs USING btree (sluggable_type);
+CREATE INDEX index_friendly_id_slugs_on_sluggable_type ON friendly_id_slugs USING btree (sluggable_type);
 
 
 --
 -- Name: index_group_memberships_on_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_group_memberships_on_group_id ON public.group_memberships USING btree (group_id);
+CREATE INDEX index_group_memberships_on_group_id ON group_memberships USING btree (group_id);
 
 
 --
 -- Name: index_group_memberships_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_group_memberships_on_reader_id ON public.group_memberships USING btree (reader_id);
+CREATE INDEX index_group_memberships_on_reader_id ON group_memberships USING btree (reader_id);
 
 
 --
 -- Name: index_groups_on_context_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_groups_on_context_id ON public.groups USING btree (context_id);
+CREATE INDEX index_groups_on_context_id ON groups USING btree (context_id);
 
 
 --
 -- Name: index_invitations_on_community_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_invitations_on_community_id ON public.invitations USING btree (community_id);
+CREATE INDEX index_invitations_on_community_id ON invitations USING btree (community_id);
 
 
 --
 -- Name: index_invitations_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_invitations_on_reader_id ON public.invitations USING btree (reader_id);
+CREATE INDEX index_invitations_on_reader_id ON invitations USING btree (reader_id);
 
 
 --
 -- Name: index_libraries_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_libraries_on_slug ON public.libraries USING btree (slug);
+CREATE UNIQUE INDEX index_libraries_on_slug ON libraries USING btree (slug);
 
 
 --
 -- Name: index_link_expansion_visibilities_on_edgenote_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_link_expansion_visibilities_on_edgenote_id ON public.link_expansion_visibilities USING btree (edgenote_id);
+CREATE INDEX index_link_expansion_visibilities_on_edgenote_id ON link_expansion_visibilities USING btree (edgenote_id);
+
+
+--
+-- Name: index_locks_on_case_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_locks_on_case_id ON locks USING btree (case_id);
+
+
+--
+-- Name: index_locks_on_lockable_type_and_lockable_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_locks_on_lockable_type_and_lockable_id ON locks USING btree (lockable_type, lockable_id);
+
+
+--
+-- Name: index_locks_on_reader_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_locks_on_reader_id ON locks USING btree (reader_id);
 
 
 --
 -- Name: index_managerships_on_library_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_managerships_on_library_id ON public.managerships USING btree (library_id);
+CREATE INDEX index_managerships_on_library_id ON managerships USING btree (library_id);
 
 
 --
 -- Name: index_managerships_on_manager_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_managerships_on_manager_id ON public.managerships USING btree (manager_id);
+CREATE INDEX index_managerships_on_manager_id ON managerships USING btree (manager_id);
 
 
 --
 -- Name: index_pages_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_pages_on_case_id ON public.pages USING btree (case_id);
+CREATE INDEX index_pages_on_case_id ON pages USING btree (case_id);
 
 
 --
 -- Name: index_podcasts_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_podcasts_on_case_id ON public.podcasts USING btree (case_id);
+CREATE INDEX index_podcasts_on_case_id ON podcasts USING btree (case_id);
 
 
 --
 -- Name: index_questions_on_quiz_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_questions_on_quiz_id ON public.questions USING btree (quiz_id);
+CREATE INDEX index_questions_on_quiz_id ON questions USING btree (quiz_id);
 
 
 --
 -- Name: index_quizzes_on_author_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quizzes_on_author_id ON public.quizzes USING btree (author_id);
+CREATE INDEX index_quizzes_on_author_id ON quizzes USING btree (author_id);
 
 
 --
 -- Name: index_quizzes_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quizzes_on_case_id ON public.quizzes USING btree (case_id);
+CREATE INDEX index_quizzes_on_case_id ON quizzes USING btree (case_id);
 
 
 --
 -- Name: index_quizzes_on_lti_uid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quizzes_on_lti_uid ON public.quizzes USING btree (lti_uid);
+CREATE INDEX index_quizzes_on_lti_uid ON quizzes USING btree (lti_uid);
 
 
 --
 -- Name: index_quizzes_on_template_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quizzes_on_template_id ON public.quizzes USING btree (template_id);
+CREATE INDEX index_quizzes_on_template_id ON quizzes USING btree (template_id);
 
 
 --
 -- Name: index_readers_on_active_community_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_readers_on_active_community_id ON public.readers USING btree (active_community_id);
+CREATE INDEX index_readers_on_active_community_id ON readers USING btree (active_community_id);
 
 
 --
 -- Name: index_readers_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_readers_on_confirmation_token ON public.readers USING btree (confirmation_token);
+CREATE UNIQUE INDEX index_readers_on_confirmation_token ON readers USING btree (confirmation_token);
 
 
 --
 -- Name: index_readers_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_readers_on_email ON public.readers USING btree (email);
+CREATE UNIQUE INDEX index_readers_on_email ON readers USING btree (email);
 
 
 --
 -- Name: index_readers_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_readers_on_reset_password_token ON public.readers USING btree (reset_password_token);
+CREATE UNIQUE INDEX index_readers_on_reset_password_token ON readers USING btree (reset_password_token);
 
 
 --
 -- Name: index_readers_roles_on_reader_id_and_role_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_readers_roles_on_reader_id_and_role_id ON public.readers_roles USING btree (reader_id, role_id);
+CREATE INDEX index_readers_roles_on_reader_id_and_role_id ON readers_roles USING btree (reader_id, role_id);
 
 
 --
 -- Name: index_reply_notifications_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_reply_notifications_on_reader_id ON public.reply_notifications USING btree (reader_id);
+CREATE INDEX index_reply_notifications_on_reader_id ON reply_notifications USING btree (reader_id);
 
 
 --
 -- Name: index_roles_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_roles_on_name ON public.roles USING btree (name);
+CREATE INDEX index_roles_on_name ON roles USING btree (name);
 
 
 --
 -- Name: index_roles_on_name_and_resource_type_and_resource_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_roles_on_name_and_resource_type_and_resource_id ON public.roles USING btree (name, resource_type, resource_id);
+CREATE INDEX index_roles_on_name_and_resource_type_and_resource_id ON roles USING btree (name, resource_type, resource_id);
 
 
 --
 -- Name: index_submissions_on_quiz_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_submissions_on_quiz_id ON public.submissions USING btree (quiz_id);
+CREATE INDEX index_submissions_on_quiz_id ON submissions USING btree (quiz_id);
 
 
 --
 -- Name: index_submissions_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_submissions_on_reader_id ON public.submissions USING btree (reader_id);
+CREATE INDEX index_submissions_on_reader_id ON submissions USING btree (reader_id);
 
 
 --
 -- Name: index_visits_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_visits_on_user_id ON public.visits USING btree (user_id);
+CREATE INDEX index_visits_on_user_id ON visits USING btree (user_id);
 
 
 --
 -- Name: index_visits_on_visit_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_visits_on_visit_token ON public.visits USING btree (visit_token);
+CREATE UNIQUE INDEX index_visits_on_visit_token ON visits USING btree (visit_token);
 
 
 --
@@ -2354,6 +2424,14 @@ ALTER TABLE ONLY answers
 
 ALTER TABLE ONLY enrollments
     ADD CONSTRAINT fk_rails_0411d261ff FOREIGN KEY (case_id) REFERENCES cases(id);
+
+
+--
+-- Name: locks fk_rails_18e2ec121a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY locks
+    ADD CONSTRAINT fk_rails_18e2ec121a FOREIGN KEY (reader_id) REFERENCES readers(id);
 
 
 --
@@ -2450,6 +2528,14 @@ ALTER TABLE ONLY comment_threads
 
 ALTER TABLE ONLY editorships
     ADD CONSTRAINT fk_rails_65154bc221 FOREIGN KEY (editor_id) REFERENCES readers(id);
+
+
+--
+-- Name: locks fk_rails_6f28fa384a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY locks
+    ADD CONSTRAINT fk_rails_6f28fa384a FOREIGN KEY (case_id) REFERENCES cases(id);
 
 
 --
@@ -2721,6 +2807,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180405141157'),
 ('20180405181811'),
 ('20180423145615'),
-('20180502185535');
+('20180502185535'),
+('20180503154001'),
+('20180518184926');
 
 

--- a/flow-typed/npm/lodash.debounce_v4.x.x.js
+++ b/flow-typed/npm/lodash.debounce_v4.x.x.js
@@ -1,0 +1,13 @@
+declare type DebounceOptions = {
+  leading?: boolean,
+  maxWait?: number,
+  trailing?: boolean,
+}
+
+declare module 'lodash.debounce' {
+  declare module.exports: <F: Function>(
+    func: F,
+    wait?: number,
+    options?: DebounceOptions
+  ) => F
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "immutability-helper": "^2.4.0",
     "intl": "^1.2.5",
     "loader-utils": "1.1.0",
+    "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "markdown-draft-js": "^0.6.0",
     "path-to-regexp": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,6 +4831,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"


### PR DESCRIPTION
### Happy path
1. Person A starts editing a card or something else that’s lockable
2. The client takes out a lock
    ```HTTP
    POST /locks

    { "lock": { "lockable_type": "Card", "lockable_param": 1 } }
    ```
    and registers the lock object (which belongs to them) in the redux store
3. The server broadcasts the lock on the `EditsChannel` and all other clients also register it
4. All clients disable editing of a card if there’s a lock on that card that they don’t own
5. Person A’s changes are queued in Redux and saved periodically. When they stop editing the card (blur) the deletion of the lock is queued too.
5. When the client tries to PUT their changes, the server checks that if there’s a lock, it’s owned by the Person A.
6. After the changes are persisted, the client deletes their lock
    ```HTTP
    DELETE /locks/:id
    ```
7. The removal of the lock is broadcasted and all clients remove it from their register

If someone else has a lock
1. Person B can click “edit anyway,” taking responsibility, and their client will delete the other person’s lock and create a new one. (How important is it that this be atomic?)
2. The broadcast of the new lock will disable editing by Person A, and the broadcasting of Person B’s changes will overwrite Person A’s data. (Can we keep a local copy?)

### Failure states
+ Try to take a lock on something that’s already locked: `409 Conflict` and the applicable lock in the body
+ Try to update or delete something someone else has locked: `423 Locked` and the authoritative contents of the element in the body