### PR TITLE
Remove limit in `part_of_catalog` scope

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,10 +4,11 @@
 class TagsController < ApplicationController
   # @route [GET] `/tags`
   def index
-    @tags = Tag.most_popular
-               .yield_self(&method(:filtered))
-               .yield_self(&method(:matching_query))
-               .sort_by(&:display_name)
+    @tags = Tag
+            .yield_self(&method(:filtered))
+            .yield_self(&method(:matching_query))
+            .most_popular
+            .sort_by(&:display_name)
 
     render json: @tags
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -26,12 +26,13 @@ class Tag < ApplicationRecord
   # one public case
   scope :part_of_catalog, -> do
     where id: (
-      joins(Arel.sql(<<~SQL.squish)).pluck(:id) \
+      joins(Arel.sql(<<~SQL.squish))
         INNER JOIN taggings ON tags.id = taggings.tag_id
         INNER JOIN cases
           ON taggings.case_id = cases.id AND cases.published_at < NOW()
       SQL
-      + where(category: true).pluck(:id)
+      .limit(false) # If the consumer has limited before this scope, it breaks
+      .pluck(:id) + where(category: true).limit(false).pluck(:id)
     )
   end
 


### PR DESCRIPTION
Because we can't select distinct unless we couple the select clause to 
the order set in `most_popular`, we are adding the two lists of ids and 
using a subquery. If we limit a relation that we later scope with this, 
the limits apply to the unordered, indistict query and limit the 
resulting tag list to very few. We can get around this by explicitly 
unsetting the limit in the subquery.