### PR TITLE
Check for json type in search index materialized view

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -37,6 +37,7 @@ class Case < ApplicationRecord
 
   attribute :authors, :json, default: []
   attribute :commentable, default: true
+  attribute :learning_objectives, :json, default: []
   attribute :locale, :string, default: -> { I18n.locale }
   attribute :slug, :string, default: -> { SecureRandom.uuid }
   attribute :translators, :json, default: []

--- a/db/migrate/20180828192116_check_type_of_learning_objectives_in_cases_search_index.rb
+++ b/db/migrate/20180828192116_check_type_of_learning_objectives_in_cases_search_index.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class CheckTypeOfLearningObjectivesInCasesSearchIndex < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      DROP INDEX IF EXISTS index_cases_on_full_text;
+      DROP INDEX IF EXISTS index_cases_search_index;
+      DROP MATERIALIZED VIEW IF EXISTS cases_search_index;
+    SQL
+
+    execute <<~SQL.squish
+      CREATE MATERIALIZED VIEW cases_search_index AS
+      SELECT cases.id AS id,
+             setweight(to_tsvector(coalesce(cases.kicker, '')), 'A')
+               || setweight(to_tsvector(coalesce(cases.title, '')), 'A')
+               || setweight(to_tsvector(coalesce(cases.dek, '')), 'A')
+               || setweight(to_tsvector(coalesce(cases.summary, '')), 'A')
+               || setweight(
+                    jsonb_path_to_tsvector(
+                      CASE WHEN jsonb_typeof(learning_objectives) <> 'array'
+                           THEN '[]'::jsonb
+                           ELSE learning_objectives
+                       END,
+                      '{}'
+                    ),
+                    'B'
+                  )
+               || jsonb_path_to_tsvector(cases.authors, '{name}')
+               || setweight(
+                    to_tsvector(coalesce(string_agg(pages.title, ' '), '')),
+                    'B'
+                  )
+               || setweight(
+                    to_tsvector(coalesce(string_agg(podcasts.title, ' '), '')),
+                    'B'
+                  )
+               || setweight(
+                    to_tsvector(
+                      coalesce(string_agg(activities.title, ' '), '')
+                    ),
+                    'B'
+                  )
+               || to_tsvector(coalesce(string_agg(podcasts.credits, ' '), ''))
+               || coalesce(
+                    tsvector_agg(
+                      jsonb_path_to_tsvector(
+                        cards.raw_content->'blocks',
+                        '{text}'
+                      )
+                    ),
+                    to_tsvector('')
+                  )
+             AS document
+        FROM cases
+        LEFT JOIN pages ON pages.case_id = cases.id
+        LEFT JOIN podcasts ON podcasts.case_id = cases.id
+        LEFT JOIN activities ON activities.case_id = cases.id
+        LEFT JOIN cards ON cards.case_id = cases.id
+          GROUP BY cases.id;
+
+      CREATE UNIQUE INDEX index_cases_search_index ON cases_search_index
+             USING btree(id);
+
+      CREATE INDEX index_cases_on_full_text ON cases_search_index
+             USING gin(document);
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1649,7 +1649,11 @@ ALTER TABLE ONLY cases
 
 CREATE MATERIALIZED VIEW cases_search_index AS
  SELECT cases.id,
-    ((((((((((setweight(to_tsvector(COALESCE(cases.kicker, ''::text)), 'A'::"char") || setweight(to_tsvector(COALESCE(cases.title, ''::text)), 'A'::"char")) || setweight(to_tsvector(COALESCE(cases.dek, ''::text)), 'A'::"char")) || setweight(to_tsvector(COALESCE(cases.summary, ''::text)), 'A'::"char")) || setweight(jsonb_path_to_tsvector(cases.learning_objectives, '{}'::text[]), 'B'::"char")) || jsonb_path_to_tsvector(cases.authors, '{name}'::text[])) || setweight(to_tsvector(COALESCE(string_agg(pages.title, ' '::text), ''::text)), 'B'::"char")) || setweight(to_tsvector(COALESCE(string_agg(podcasts.title, ' '::text), ''::text)), 'B'::"char")) || setweight(to_tsvector(COALESCE(string_agg(activities.title, ' '::text), ''::text)), 'B'::"char")) || to_tsvector(COALESCE(string_agg(podcasts.credits, ' '::text), ''::text))) || COALESCE(tsvector_agg(jsonb_path_to_tsvector((cards.raw_content -> 'blocks'::text), '{text}'::text[])), to_tsvector(''::text))) AS document
+    ((((((((((setweight(to_tsvector(COALESCE(cases.kicker, ''::text)), 'A'::"char") || setweight(to_tsvector(COALESCE(cases.title, ''::text)), 'A'::"char")) || setweight(to_tsvector(COALESCE(cases.dek, ''::text)), 'A'::"char")) || setweight(to_tsvector(COALESCE(cases.summary, ''::text)), 'A'::"char")) || setweight(jsonb_path_to_tsvector(
+        CASE
+            WHEN (jsonb_typeof(cases.learning_objectives) <> 'array'::text) THEN '[]'::jsonb
+            ELSE cases.learning_objectives
+        END, '{}'::text[]), 'B'::"char")) || jsonb_path_to_tsvector(cases.authors, '{name}'::text[])) || setweight(to_tsvector(COALESCE(string_agg(pages.title, ' '::text), ''::text)), 'B'::"char")) || setweight(to_tsvector(COALESCE(string_agg(podcasts.title, ' '::text), ''::text)), 'B'::"char")) || setweight(to_tsvector(COALESCE(string_agg(activities.title, ' '::text), ''::text)), 'B'::"char")) || to_tsvector(COALESCE(string_agg(podcasts.credits, ' '::text), ''::text))) || COALESCE(tsvector_agg(jsonb_path_to_tsvector((cards.raw_content -> 'blocks'::text), '{text}'::text[])), to_tsvector(''::text))) AS document
    FROM ((((cases
      LEFT JOIN pages ON ((pages.case_id = cases.id)))
      LEFT JOIN podcasts ON ((podcasts.case_id = cases.id)))
@@ -2997,6 +3001,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180806201126'),
 ('20180806201127'),
 ('20180824210458'),
-('20180827153920');
+('20180827153920'),
+('20180828192116');
 
 


### PR DESCRIPTION
Sometimes `learning_objectives` isn’t properly a json array. If it is set to `""::jsonb` or something like that, the query for the materialized view used for the search would blow up. Now we check the type, which takes care of that.

Fixes #418 