### PR TITLE
Don’t crash when a comment’s selection has changed

### DIFF
--- a/app/javascript/conversation/LeadComment.jsx
+++ b/app/javascript/conversation/LeadComment.jsx
@@ -41,10 +41,15 @@ type OwnProps = {
   onCancel: (SyntheticMouseEvent<*>) => Promise<any>,
 }
 
-function mapStateToProps ({ caseData }: State) {
+function mapStateToProps (
+  { caseData, commentThreadsById }: State,
+  { threadId }: OwnProps
+) {
   const { reader } = caseData
+  const thread = commentThreadsById[threadId]
   return {
     readerCanDeleteComments: reader?.canUpdateCase,
+    threadDetached: thread.start == null || thread.blockIndex == null,
   }
 }
 type StateProps = { readerCanDeleteComments: boolean }
@@ -83,6 +88,7 @@ const LeadComment = ({
   readerCanDeleteComments,
   responseCount,
   threadId,
+  threadDetached,
   onCancel,
 }: Props) => (
   <>
@@ -94,6 +100,12 @@ const LeadComment = ({
     {page != null &&
       inSituPath != null && (
       <CommentThreadLocation>
+        {threadDetached && (
+          <Callout>
+            <FormattedMessage id="commentThreads.show.textChanged" />
+          </Callout>
+        )}
+
         <CommentThreadBreadcrumbs>
           <CommentThreadBreadcrumb>
             {inSitu ? (
@@ -115,6 +127,7 @@ const LeadComment = ({
             />
           </CommentThreadBreadcrumb>
         </CommentThreadBreadcrumbs>
+
         <HighlightedText disabled={inSitu}>
           <Link
             to={inSituPath}
@@ -188,6 +201,12 @@ const LeadCommenter = styled.div`
 
 const CommentThreadLocation = styled.div`
   margin: 18px 0 28px;
+`
+
+const Callout = styled.div.attrs({ className: 'pt-callout pt-icon-error' })`
+  line-height: 1.3;
+  font-weight: 400;
+  margin-bottom: 1em;
 `
 
 const HighlightedText = styled.div`

--- a/app/javascript/redux/reducers/cards.js
+++ b/app/javascript/redux/reducers/cards.js
@@ -7,7 +7,17 @@ import { EditorState, convertFromRaw } from 'draft-js'
 import { decorator } from 'draft/config'
 
 // $FlowFixMe
-import { omit, lensPath, view, set, reduce } from 'ramda'
+import {
+  complement,
+  isNil,
+  filter,
+  where,
+  omit,
+  lensPath,
+  view,
+  set,
+  reduce,
+} from 'ramda'
 
 import type { RawDraftContentState } from 'draft-js/lib/RawDraftContentState'
 
@@ -221,5 +231,9 @@ function addCommentThreads (content: RawDraftContentState, card: Card) {
       content
     )
 
-  return reduce(setInlineStylesForComment, content, commentThreads)
+  const attached = filter(
+    where({ blockIndex: complement(isNil), start: complement(isNil) })
+  )
+
+  return reduce(setInlineStylesForComment, content, attached(commentThreads))
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,7 @@ en:
       comments_on_page: Comments on “{title}”
       comments_on_page_number: Comments on Page {position, number}
       page_n: Page {pageNumber, number}
+      text_changed: The text being discussed has changed since this conversation started.
   comments:
     destroy:
       delete_comment: Delete comment

--- a/spec/features/editing_a_case_spec.rb
+++ b/spec/features/editing_a_case_spec.rb
@@ -126,6 +126,34 @@ feature 'Editing a case' do
         expect(entity.text.strip)
           .to eq comment_thread.original_highlight_text.strip
       end
+
+      scenario 'detaches the comment thread if its text is changed' do
+        comment_thread.comments.create! content: 'Test comment', reader: reader
+        visit case_path kase
+        click_on 'Enroll'
+        visit case_path(kase) + '/1'
+
+        expect(page).to have_selector 'span.c-comment-thread-entity'
+
+        click_on 'Edit this case'
+        find('.c-comment-thread-entity', match: :first).click
+        page.driver.browser.action
+            .send_keys('new text added')
+            .perform
+        click_on 'Save'
+        expect(page).to have_content 'Saved successfully'
+
+        page.driver.browser.navigate.refresh
+        expect(page).to have_content 'new text added'
+        expect(page).not_to have_selector 'span.c-comment-thread-entity'
+        expect(page).to have_content '1 COMMENT'
+
+        click_on '1 comment'
+        expect(page).to have_content 'Test comment'
+
+        click_on 'Test comment'
+        expect(page).to have_content 'The text being discussed has changed'
+      end
     end
   end
 


### PR DESCRIPTION
Deleted the code which handled this (c38312a) nearly a year ago, and 
because we didn’t have a test for it, we didn’t realize.