### PR TITLE
Rescue OEmbed::UnknownResponse with {}

### DIFF
--- a/app/models/link_expansion/embed.rb
+++ b/app/models/link_expansion/embed.rb
@@ -5,7 +5,7 @@ class LinkExpansion
   class Embed
     def self.for(url, with_visibility:)
       new(url, with_visibility)
-    rescue OEmbed::NotFound
+    rescue OEmbed::NotFound, OEmbed::UnknownResponse
       {}
     end
 


### PR DESCRIPTION
It’s not considered an error if we can’t show a preview for a link the user adds if that url returns an error response

https://sentry.io/share/issue/ad8b211312694b78b943dc13436fb24a/