### PR TITLE
Limit deployments to one per case per group

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -25,6 +25,7 @@ class Deployment < ApplicationRecord
 
   accepts_nested_attributes_for :group
 
+  validates :case_id, uniqueness: { scope: :group_id }
   validates :quiz, presence: true, if: -> { answers_needed.positive? }
 
   after_create :create_forum

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,16 +97,20 @@ en:
           has_many: "Cannot delete record because dependent %{record} exist"
           has_one: "Cannot delete record because a dependent %{record} exists"
       models:
-        question:
+        deployment:
           attributes:
-            correct_answer:
-              inclusion: "is not included in the list of possible answers"
+            case_id:
+              taken: has already been deployed in this study group
         editorship:
           attributes:
             editor:
               required: |
                 could not be found. Please ensure your collaborator has created
                 an account with the email you have entered.
+        question:
+          attributes:
+            correct_answer:
+              inclusion: "is not included in the list of possible answers"
     models:
       activity: Activity
       case: Case

--- a/db/migrate/20181030194657_add_unique_index_on_case_and_group_to_deployments.rb
+++ b/db/migrate/20181030194657_add_unique_index_on_case_and_group_to_deployments.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'matrix'
+
+class AddUniqueIndexOnCaseAndGroupToDeployments < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        delete_duplicate_deployments
+      end
+    end
+
+    add_index :deployments, %i[group_id case_id], unique: true
+  end
+
+  private
+
+  def delete_duplicate_deployments
+    say 'deleting duplicate deployments'
+    deployments_to_delete.each(&:destroy)
+  end
+
+  def deployments_to_delete
+    non_unique_deployments
+      .order(created_at: :asc)
+      .group_by { |d| [d.case_id, d.group_id] }
+      .values
+      .flat_map { |ds| ds[1..-1] }
+  end
+
+  def non_unique_deployments
+    case_ids, group_ids = Matrix[*duplicate_pairs].transpose.to_a
+    Deployment.where(case_id: case_ids, group_id: group_ids)
+  end
+
+  def duplicate_pairs
+    Deployment.group(:case_id, :group_id).having('count(*) > 1')
+              .pluck(:case_id, :group_id)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2142,6 +2142,13 @@ CREATE INDEX index_deployments_on_group_id ON deployments USING btree (group_id)
 
 
 --
+-- Name: index_deployments_on_group_id_and_case_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_deployments_on_group_id_and_case_id ON deployments USING btree (group_id, case_id);
+
+
+--
 -- Name: index_deployments_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2942,6 +2949,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180911154308'),
 ('20180911155612'),
 ('20180919145935'),
-('20181029165916');
+('20181029165916'),
+('20181030194657');
 
 

--- a/spec/features/creating_a_new_deployment_spec.rb
+++ b/spec/features/creating_a_new_deployment_spec.rb
@@ -9,16 +9,16 @@ feature 'Creating a new deployment' do
   scenario 'is possible' do
     kase = create :case, :published
     visit case_path kase
-    click_button 'Deploy this Case'
-    click_button 'Create Deployment'
+    click_on 'Deploy this Case'
+    click_on 'Create Deployment'
     expect(page).to have_content 'Group name can’t be blank'
 
     select 'Create a New Study Group', from: 'Study Group'
     fill_in 'Group Name', with: 'My Study Group'
-    click_button 'Create Deployment'
+    click_on 'Create Deployment'
     expect(page).to have_content 'Deployment successfully created'
 
-    click_button 'Invite Learners'
+    click_on 'Invite Learners'
     expect(page).to have_content 'Send someone this link to invite them to study this case with you.'
 
     magic_link = find('[aria-label^="Invite link"]')
@@ -28,10 +28,31 @@ feature 'Creating a new deployment' do
 
     cas = create :case, :published
     visit case_path cas
-    click_button 'Deploy this Case'
+    click_on 'Deploy this Case'
     select 'My Study Group', from: 'Study Group'
-    click_button 'Create Deployment'
+    click_on 'Create Deployment'
     expect(page).to have_content 'Deployment successfully created'
     expect(page).to have_content 'Invite Learners', count: 2
+  end
+
+  context 'of the same case in the same group' do
+    it 'shows an error message' do
+      kase = create :case, :published
+      visit case_path kase
+      click_on 'Deploy this Case'
+      click_on 'Create Deployment'
+      expect(page).to have_content 'Group name can’t be blank'
+
+      select 'Create a New Study Group', from: 'Study Group'
+      fill_in 'Group Name', with: 'My Study Group'
+      click_on 'Create Deployment'
+      expect(page).to have_content 'Deployment successfully created'
+
+      visit case_path kase
+      click_on 'Deploy this Case'
+      select 'My Study Group', from: 'Study Group'
+      click_on 'Create Deployment'
+      expect(page).to have_content 'Case has already been deployed in this study group'
+    end
   end
 end


### PR DESCRIPTION
This PR also includes a migration to delete the later-created of the currently non-unique deployments

Migrations: **YES**