### PR TITLE
Don’t try to create a lock on a card when leaving a comment

### DIFF
--- a/app/javascript/card/CardContents.jsx
+++ b/app/javascript/card/CardContents.jsx
@@ -167,9 +167,9 @@ class CardContents extends React.Component<Props, State> {
                     editorState={editorState}
                     handleKeyCommand={handleKeyCommand}
                     handleBeforeInput={handleBeforeInput}
-                    onFocus={onBeginEditing}
+                    onFocus={editable ? onBeginEditing : () => {}}
                     onChange={onChange}
-                    onBlur={onFinishEditing}
+                    onBlur={editable ? onFinishEditing : () => {}}
                   />
                 </FocusContainer>
 

--- a/spec/features/leaving_a_comment_spec.rb
+++ b/spec/features/leaving_a_comment_spec.rb
@@ -195,4 +195,20 @@ feature 'Leaving a comment' do
       expect(email).to be_nil
     end
   end
+
+  context 'as an author of the case' do
+    it 'doesn’t lock the card you’re commenting on' do
+      kase = enrollment.case
+      card = kase.pages.first.cards.first
+
+      enrollment.reader.my_cases << kase
+
+      visit case_path(enrollment.case) + '/1'
+      click_link 'Respond', match: :first
+      first_paragraph = find('.DraftEditor-root div[data-block]', match: :first)
+      first_paragraph.double_click
+
+      expect(card).not_to be_locked
+    end
+  end
 end


### PR DESCRIPTION
It should not try to get a lock when making a selection for comment, even though the DraftEditor is being edited.

https://sentry.io/share/issue/c6cc67c01350429f94e4b7ed0545174d/