### PR TITLE
Allow cases with nil kickers to be deleted

### DIFF
--- a/app/forms/confirm_deletion_form.rb
+++ b/app/forms/confirm_deletion_form.rb
@@ -7,7 +7,7 @@ class ConfirmDeletionForm
 
   attr_accessor :case, :kicker_confirmation
 
-  validate :kicker_confirmed?
+  validate :kicker_confirmed?, if: :needs_confirmation?
 
   def needs_confirmation?
     self.case.kicker.present?
@@ -15,6 +15,7 @@ class ConfirmDeletionForm
 
   def save
     return unless valid?
+
     delete_case
     true
   end
@@ -23,6 +24,7 @@ class ConfirmDeletionForm
 
   def kicker_confirmed?
     return if kicker_confirmation == self.case.kicker
+
     errors.add :kicker_confirmation, :match
   end
 

--- a/spec/forms/confirm_deletiong_form_spec.rb
+++ b/spec/forms/confirm_deletiong_form_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ConfirmDeletionForm, type: :model do
+  let(:kase) { build_stubbed :case }
+
+  it 'is valid if kicker is confirmed' do
+    kase.kicker = 'Kicker'
+    form = described_class.new case: kase, kicker_confirmation: 'Kicker'
+    expect(form).to be_valid
+  end
+
+  it 'is invalid if kicker confirmation doesn’t match' do
+    kase.kicker = 'Kicker'
+    form = described_class.new case: kase, kicker_confirmation: 'Wrong'
+    expect(form).not_to be_valid
+  end
+
+  it 'is valid if kicker is blank and confirmation matches' do
+    kase.kicker = ''
+    form = described_class.new case: kase, kicker_confirmation: ''
+    expect(form).to be_valid
+  end
+
+  it 'is valid if kicker is nil and confirmation is blank' do
+    kase.kicker = nil
+    form = described_class.new case: kase, kicker_confirmation: ''
+    expect(form).to be_valid
+  end
+
+  it 'deletes the case if saved while valid' do
+    kase.kicker = 'Kicker'
+    allow(kase).to receive :destroy
+
+    form = described_class.new case: kase, kicker_confirmation: 'Kicker'
+    form.save
+
+    expect(kase).to have_received :destroy
+  end
+
+  it 'does not delete the case if saved while invalid' do
+    kase.kicker = 'Kicker'
+    allow(kase).to receive :destroy
+
+    form = described_class.new case: kase, kicker_confirmation: 'Wrong'
+    form.save
+
+    expect(kase).not_to have_received :destroy
+  end
+end


### PR DESCRIPTION
We don’t ask the user to type the case kicker when it is blank, but we failed to permit the deletion when the kicker is not `''` but `nil`. This fixes that.