### PR TITLE
Show the first editor on my_cases#index for admins

### DIFF
--- a/app/models/editorship.rb
+++ b/app/models/editorship.rb
@@ -4,6 +4,8 @@
 # ability to edit it. That Reader association is called {editor} to distinguish
 # it from the readers connected to a case through {Enrollment}s
 class Editorship < ApplicationRecord
+  default_scope -> { order :created_at }
+
   attribute :editor_email, :string
 
   belongs_to :case, inverse_of: :editorships

--- a/app/views/my_cases/index.html.haml
+++ b/app/views/my_cases/index.html.haml
@@ -31,7 +31,10 @@
         %thead
           %td
           %td= t 'activerecord.attributes.case.case_title'
-          %td= t 'activerecord.attributes.case.slug'
+          - if current_reader.has_role? :editor
+            %td First Editor
+          - else
+            %td= t 'activerecord.attributes.case.slug'
           %td= t 'activerecord.attributes.case.locale'
           %td= t 'activerecord.attributes.case.library'
           %td= t 'activerecord.attributes.case.published'
@@ -57,9 +60,12 @@
                         = localize kase.featured_at.to_date
                   = kase.title
 
-              %td
-                = link_to case_path kase do
-                  %code= kase.slug
+              - if current_reader.has_role? :editor
+                %td= kase.editorships.first&.editor_name
+              - else
+                %td
+                  = link_to case_path kase do
+                    %code= kase.slug
 
               %td= Translation.language_name kase.locale
 


### PR DESCRIPTION
Since admins can see cases that everyone has created, it is more helpful to list
the authors (identified by their account, not by case contents)