### PR TITLE
Fix 500 when creating an editorship with bad data

### DIFF
--- a/app/views/editorships/_list.html.haml
+++ b/app/views/editorships/_list.html.haml
@@ -1,6 +1,6 @@
 %h2.deployments__group= t '.case_editors'
 
-- editorships.sort_by(&:editor_name).each do |editorship|
+- editorships.select(&:persisted?).sort_by(&:editor_name).each do |editorship|
   .editorship.non-spaced
     %span.pt-tag.pt-minimal= editorship.editor_name
     - unless editorship.editor == current_reader

--- a/spec/features/adding_a_collaborator_spec.rb
+++ b/spec/features/adding_a_collaborator_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Adding a collaborator' do
+  let!(:reader) { create :reader }
+  let!(:case_study) do
+    create(:case).tap { |c| reader.my_cases << c }
+  end
+
+  before { login_as reader }
+
+  context 'with an account' do
+    scenario 'is possible' do
+      collaborator = create :reader
+
+      visit case_path case_study
+      click_on 'Edit this case'
+      click_on 'Add Collaborator'
+
+      fill_in 'Collaborator’s Email', with: collaborator.email
+      click_on 'Add Collaborator'
+
+      expect(page).to have_content 'Editorship successfully created'
+      expect(page).to have_content collaborator.name
+    end
+  end
+
+  context 'without an account' do
+    scenario 'shows an error message' do
+      visit case_path case_study
+      click_on 'Edit this case'
+      click_on 'Add Collaborator'
+
+      fill_in 'Collaborator’s Email', with: 'nonexistantuser@email.com'
+      click_on 'Add Collaborator'
+
+      expect(page).to have_content 'collaborator’s account could not be found'
+    end
+  end
+end


### PR DESCRIPTION
Removes unpersisted editorship from list to be displayed, since we had type
errors with the invalid data.

Closes #550