### PR TITLE
Fix interface when locale is something other than English

### DIFF
--- a/app/javascript/overview/keywords/KeywordsDisplay.jsx
+++ b/app/javascript/overview/keywords/KeywordsDisplay.jsx
@@ -23,18 +23,21 @@ const KeywordsDisplay = ({ tags }: Props) => (
         .map(({ name, displayName }) => (
           <CategoryTag
             key={name}
-            category={displayName}
+            category={name}
+            label={displayName}
             href={categoryQueryPath(name)}
           />
         ))}
     </div>
 
     <div className="pt-dark">
-      {tags.filter(tag => !tag.category).map(({ name, displayName }) => (
-        <KeywordTag key={name} href={categoryQueryPath(name)}>
-          {displayName}
-        </KeywordTag>
-      ))}
+      {tags
+        .filter(tag => !tag.category)
+        .map(({ name, displayName }) => (
+          <KeywordTag key={name} href={categoryQueryPath(name)}>
+            {displayName}
+          </KeywordTag>
+        ))}
     </div>
   </>
 )
@@ -52,7 +55,7 @@ const CategoryTag = styled.a.attrs({ className: 'pt-tag pt-large' })`
   padding: 0.5em 1em !important;
 
   &::before {
-    content: '${p => p.category}';
+    content: '${p => p.name}';
     text-transform: capitalize;
   }
 

--- a/app/javascript/packs/billboard.entry.jsx
+++ b/app/javascript/packs/billboard.entry.jsx
@@ -33,7 +33,7 @@ Promise.all([
   import(`react-intl/locale-data/${locale.substring(0, 2)}`),
   loadMessages(locale),
 ]).then(([localeData, messages]) => {
-  addLocaleData(localeData)
+  addLocaleData(localeData.default)
 
   if (container != null) {
     ReactDOM.render(

--- a/app/javascript/packs/case.entry.jsx
+++ b/app/javascript/packs/case.entry.jsx
@@ -34,7 +34,7 @@ Promise.all([
   import(`react-intl/locale-data/${locale.substring(0, 2)}`),
   loadMessages(locale),
 ]).then(([localeData, messages]) => {
-  addLocaleData(localeData)
+  addLocaleData(localeData.default)
   ReactDOM.render(
     <ErrorBoundary>
       <Provider store={store}>

--- a/app/javascript/packs/catalog.entry.jsx
+++ b/app/javascript/packs/catalog.entry.jsx
@@ -21,7 +21,7 @@ Promise.all([
   import(`react-intl/locale-data/${locale.substring(0, 2)}`),
   loadMessages(locale),
 ]).then(([localeData, messages]) => {
-  addLocaleData(localeData)
+  addLocaleData(localeData.default)
   ReactDOM.render(
     <ErrorBoundary>
       <IntlProvider locale={locale} messages={messages}>

--- a/app/javascript/packs/deployment.entry.jsx
+++ b/app/javascript/packs/deployment.entry.jsx
@@ -20,7 +20,7 @@ Promise.all([
   import(`react-intl/locale-data/${locale.substring(0, 2)}`),
   loadMessages(locale),
 ]).then(([localeData, messages]) => {
-  addLocaleData(localeData)
+  addLocaleData(localeData.default)
   ReactDOM.render(
     <IntlProvider locale={locale} messages={messages}>
       <ThemeProvider theme={theme}>

--- a/app/javascript/packs/main-menu.entry.jsx
+++ b/app/javascript/packs/main-menu.entry.jsx
@@ -17,7 +17,7 @@ Promise.all([
   import(`react-intl/locale-data/${locale.substring(0, 2)}`),
   loadMessages(locale),
 ]).then(([localeData, messages]) => {
-  addLocaleData(localeData)
+  addLocaleData(localeData.default)
   ReactDOM.render(
     <IntlProvider locale={locale} messages={messages}>
       <MainMenu />

--- a/app/javascript/shared/MainMenu.jsx
+++ b/app/javascript/shared/MainMenu.jsx
@@ -53,12 +53,12 @@ class MainMenu extends React.Component<{ intl: IntlShape }, Reader> {
             </Menu>
           }
         >
-          <Row
+          <ButtonRow
             aria-label={formatMessage({ id: 'readers.form.accountOptions' })}
           >
             <Identicon reader={reader} />
             <CaretDown />
-          </Row>
+          </ButtonRow>
         </Popover>
       </Row>
     ) : (
@@ -96,12 +96,13 @@ const CaretDown = styled.span.attrs({
   margin-left: 8px;
   color: rgba(255, 255, 255, 0.5);
 `
-const Row = styled.div.attrs({
-  role: 'button',
-  tabIndex: '0',
-  onKeyPress: () => acceptKeyboardClick,
-})`
+const Row = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
 `
+const ButtonRow = styled(Row).attrs({
+  role: 'button',
+  tabindex: '0',
+  onKeyPress: () => acceptKeyboardClick,
+})``

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
                       .map { |fname| File.basename fname, '.yml' }
                       .map(&:to_sym)
   config.i18n.available_locales = ([:en] + available_locales).uniq
+
+  config.i18n.fallbacks = %i[en]
 end
 
 module Translation

--- a/spec/features/using_a_non_english_locale_spec.rb
+++ b/spec/features/using_a_non_english_locale_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Using a non-English locale' do
+  scenario 'the catalog and case pages load' do
+    reader = create :reader, locale: :fr, password: 'secret'
+    case_study = create :case_with_elements
+    # case_study.tag 'water'
+
+    login_as reader
+
+    click_on case_study.title
+    expect(page).to have_content 'TABLE DES MATIÈRES'
+
+    click_on case_study.pages.first.title
+    expect(page).to have_button 'Retour au résumé'
+  end
+end

--- a/spec/features/using_a_non_english_locale_spec.rb
+++ b/spec/features/using_a_non_english_locale_spec.rb
@@ -6,7 +6,7 @@ feature 'Using a non-English locale' do
   scenario 'the catalog and case pages load' do
     reader = create :reader, locale: :fr, password: 'secret'
     case_study = create :case_with_elements
-    # case_study.tag 'water'
+    case_study.tag 'water'
 
     login_as reader
 

--- a/spec/features/using_a_non_english_locale_spec.rb
+++ b/spec/features/using_a_non_english_locale_spec.rb
@@ -15,5 +15,9 @@ feature 'Using a non-English locale' do
 
     click_on case_study.pages.first.title
     expect(page).to have_button 'Retour au résumé'
+
+    # Somehow, not doing this leaves the interface in French for later tests
+    reader.update locale: :en
+    logout
   end
 end

--- a/spec/support/integration/authentication.rb
+++ b/spec/support/integration/authentication.rb
@@ -11,10 +11,14 @@ module Orchard
           click_button 'Sign in'
         end
 
-        def logout
+        def logout(locale: :en)
           visit root_path
-          find('#reader-icon').click
-          click_link 'Sign out'
+
+          options = I18n.t('readers.form.account_options', locale: locale)
+          find("[aria-label='#{options}']").click
+
+          click_on I18n.t('devise.sessions.destroy.sign_out',
+                          locale: locale)
         end
       end
     end


### PR DESCRIPTION
How wonderful: two bugs in one 🕷🦂

First, the `i18n` gem upgrade to 1.1.0 [changed the behavior of locale fallbacks](https://github.com/svenfuchs/i18n/pull/415), removing the default locale from the default list of fallbacks. We were relying on that, and when a tag had no `display_name` in the current locale, we were serializing `null`. The interface broke [when rendering the keywords index on the catalog page](https://sentry.io/share/issue/fcbc0ca23a9d4af0bd4b1ccaf884e936/) and [when loading the image backgrounds for category tags](https://sentry.io/share/issue/92da98729ee24584aa1187bc189a9132/).

Second, at some point `react-intl` locale data started being exported as an ES module, (aka with a default export), instead of a bare `module.exports = ...`, and `addLocaleData` started failing, and falling back to English. This meant that the leaf translated components were expecting English messages regardless of the locale set in `IntlProvider`. Of course, this was fine in English mode, 
and all the messages failed to load otherwise.

Needless to say, this PR adds a test that would have caught either of these bugs.