### PR TITLE
Improve error handling

### DIFF
--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -18,20 +18,17 @@ class EnrollmentsController < ApplicationController
   # @route [POST] `/cases/case-slug/enrollment`
   def create
     authorize @enrollment
-
-    if @enrollment.save
-      head :created
-    else
-      head :unprocessable_entity
-    end
+    @enrollment.save!
+    head :no_content
   end
 
   # @route [DELETE] `/cases/case-slug/enrollment`
   def destroy
-    head :no_content && return unless @enrollment
+    head :not_found && return unless @enrollment
 
     authorize @enrollment
     @enrollment.destroy
+    head :no_content
   end
 
   private

--- a/app/javascript/catalog/index.jsx
+++ b/app/javascript/catalog/index.jsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import { injectIntl } from 'react-intl'
 
 import ErrorBoundary from 'utility/ErrorBoundary'
-import { Orchard } from 'shared/orchard'
+import { Orchard, OrchardError } from 'shared/orchard'
 import {
   Provider as ContentItemSelectionContextProvider,
   Consumer as ContentItemSelectionContextConsumer,
@@ -65,8 +65,8 @@ export class Catalog extends React.Component<{ intl: IntlShape }, State> {
         `${intl.formatMessage({ id: 'enrollments.destroy.areYouSure' })}${
           options.displayBetaWarning
             ? `\n\n${intl.formatMessage({
-              id: 'enrollments.destroy.youWillNeedAnotherInvitation',
-            })}`
+                id: 'enrollments.destroy.youWillNeedAnotherInvitation',
+              })}`
             : ''
         }`
       )
@@ -84,7 +84,10 @@ export class Catalog extends React.Component<{ intl: IntlShape }, State> {
   componentDidMount () {
     Orchard.harvest('profile')
       .then(reader => this.setState({ reader }))
-      .catch(e => e.name === 'OrchardError' && this.setState({ reader: null }))
+      .catch(e => {
+        debugger
+        if (!(e instanceof OrchardError && e.status === 401)) throw e
+      })
       .then(() =>
         this.setState(({ loading }) => ({
           loading: { ...loading, reader: false },
@@ -101,9 +104,9 @@ export class Catalog extends React.Component<{ intl: IntlShape }, State> {
     )
     Orchard.harvest('enrollments')
       .then(enrollments => this.setState({ enrollments }))
-      .catch(
-        e => e.name === 'OrchardError' && this.setState({ enrollments: [] })
-      )
+      .catch(e => {
+        if (!(e instanceof OrchardError && e.status === 401)) throw e
+      })
     Orchard.harvest('tags').then(tags => this.setState({ tags }))
     Orchard.harvest('catalog/libraries').then(libraries =>
       this.setState({ libraries })

--- a/app/javascript/redux/actions/case.js
+++ b/app/javascript/redux/actions/case.js
@@ -51,9 +51,9 @@ export function togglePublished (): ThunkAction {
 
 export function enrollReader (readerId: string, caseSlug: string): ThunkAction {
   return async (dispatch: Dispatch) => {
-    const enrollment = await Orchard.graft(`cases/${caseSlug}/enrollment`, {})
+    await Orchard.graft(`cases/${caseSlug}/enrollment`, {})
 
-    dispatch(setReaderEnrollment(!!enrollment))
+    dispatch(setReaderEnrollment(true))
     dispatch(fetchCommunities(caseSlug))
     dispatch(fetchCommentThreads(caseSlug))
   }

--- a/app/javascript/redux/actions/toast.js
+++ b/app/javascript/redux/actions/toast.js
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react'
-import { updateActiveCommunity } from 'redux/actions'
+import { clearUnsaved, updateActiveCommunity } from 'redux/actions'
 
 import { Intent } from '@blueprintjs/core'
 
@@ -56,13 +56,30 @@ export function handleNotification (notification: Notification): ThunkAction {
   }
 }
 
-export function displayErrorToast (message: string | React.Node): ThunkAction {
+export type DisplayErrorToastOptions = { suggestReload?: boolean }
+export function displayErrorToast (
+  message: string | React.Node,
+  options: ?DisplayErrorToastOptions
+): ThunkAction {
+  const { suggestReload } = options || {}
+
   return (dispatch: Dispatch) => {
+    const action = suggestReload
+      ? {
+          text: 'Reload',
+          onClick: () => {
+            clearUnsaved()
+            window.location.reload()
+          },
+        }
+      : undefined
+
     dispatch(
       displayToast({
         intent: Intent.DANGER,
         icon: 'error',
         message: <span style={{ whiteSpace: 'pre-wrap' }}>{message}</span>,
+        action,
       })
     )
   }

--- a/app/javascript/shared/__tests__/orchard.test.js
+++ b/app/javascript/shared/__tests__/orchard.test.js
@@ -1,0 +1,75 @@
+/* @noflow */
+
+import { handleResponse, OrchardError, OrchardInputError } from '../orchard'
+
+global.fetch = require('jest-fetch-mock')
+
+describe('Orchard (API service)', () => {
+  describe('handleResponse', () => {
+    it('resolves parsed JSON from a successful JSON res', async () => {
+      const obj = { id: 1 }
+      const body = JSON.stringify(obj)
+      const headers = new Headers({
+        'Content-Type': 'application/json; charset=utf-8',
+      })
+      const res = new Response([body], { status: 200, headers })
+
+      await expect(handleResponse(res)).resolves.toEqual(obj)
+    })
+
+    it('resolves text contents of a non-JSON res', async () => {
+      const text = '<html><body>Success</body></html>'
+      const headers = new Headers({ 'Content-Type': 'text/plain' })
+      const res = new Response([text], { status: 200, headers })
+
+      await expect(handleResponse(res)).resolves.toEqual(text)
+    })
+
+    it('resolves with no value from a successful res with no body', async () => {
+      const res = new Response(null, { status: 204 })
+      await expect(handleResponse(res)).resolves.toBeUndefined()
+    })
+
+    it('throws if a successful res has a malformed body', async () => {
+      const body = '{ id: 1'
+      const headers = new Headers({ 'Content-Type': 'application/json' })
+      const res = new Response([body], { status: 200, headers })
+
+      const error = await handleResponse(res).catch(x => x)
+
+      expect(error).toBeInstanceOf(OrchardError)
+      expect(error.message).toEqual('Malformed response')
+    })
+
+    it('rethrows the fetch error if the request fails', async () => {
+      const res = new Response(null, { status: 404, statusText: 'Not Found' })
+
+      const error = await handleResponse(res).catch(x => x)
+
+      expect(error).toBeInstanceOf(OrchardError)
+      expect(error.message).toEqual('404 Not Found')
+    })
+
+    it('throws with human readable error messages if res is 422', async () => {
+      const errors = {
+        email: ['can’t be blank'],
+        password: [
+          'must be at least 6 characters long',
+          'must contain at least one number',
+        ],
+      }
+      const body = JSON.stringify(errors)
+      const headers = new Headers({ 'Content-Type': 'application/json' })
+      const res = new Response([body], { status: 422, headers })
+
+      const error = await handleResponse(res).catch(x => x)
+
+      expect(error).toBeInstanceOf(OrchardInputError)
+      expect(error.message).toEqual(
+        'Email can’t be blank.\n' +
+          'Password must be at least 6 characters long.\n' +
+          'Password must contain at least one number.'
+      )
+    })
+  })
+})

--- a/app/javascript/shared/orchard.js
+++ b/app/javascript/shared/orchard.js
@@ -99,11 +99,13 @@ function getMetaContent (key: string): ?string {
 }
 
 export class OrchardError extends Error {
+  status: number
   url: string
 
   constructor (response: Response, message: ?string) {
     super(message || `${response.status} ${response.statusText}`)
     this.url = response.url
+    this.status = response.status
     this.name = 'OrchardError'
   }
 }

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "flow-bin": "0.87.0",
     "flow-inspect": "^1.0.1",
     "jest": "^23.6.0",
+    "jest-fetch-mock": "^2.0.1",
     "prettier": "^1.15.2",
     "regenerator-runtime": "^0.12.1",
     "webpack-bundle-analyzer": "^3.0.3",
@@ -125,6 +126,8 @@
     "webpack-dev-server": "^3.1.10"
   },
   "jest": {
-    "modulePaths": ["<rootDir>/app/javascript"]
+    "modulePaths": [
+      "<rootDir>/app/javascript"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3123,6 +3123,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.3.tgz#e8a0b3c54598136e037f8650f8e823ccdfac198e"
+  integrity sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -6173,6 +6181,14 @@ jest-environment-node@^23.4.0:
     jest-mock "^23.2.0"
     jest-util "^23.4.0"
 
+jest-fetch-mock@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-2.0.1.tgz#aef284ee851f6c0f8b78c5367576edb6f64ca526"
+  integrity sha512-ulFW7tpQ7ihe89an+gWW8p7sMt5/smk7I0RJcZ2MXkgoM0jHVaBgqeE6XoLbXi1lWF42hK2zdnGzD8I6gSC35A==
+  dependencies:
+    cross-fetch "^2.2.2"
+    promise-polyfill "^7.1.1"
+
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
@@ -7320,6 +7336,11 @@ no-case@^2.2.0, no-case@^2.3.2:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -8998,6 +9019,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.1.2.tgz#ab05301d8c28536301622d69227632269a70ca3b"
+  integrity sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==
 
 promise@^7.1.1:
   version "7.3.1"
@@ -11773,6 +11799,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Only try to parse human readable messages from 422 responses; otherwise throw an error with the server response code and the URL that returned it.

In the autosave loop, 404s can be silently ignored. 409 Conflict and 423 Locked should cancel autosave not to overwrite. Others should rethrow for Sentry and present a reload suggestion to break the autosave loop.