### PR TITLE
Use module notation to prevent superclass mismatch

### DIFF
--- a/app/controllers/admin/ahoy/events_controller.rb
+++ b/app/controllers/admin/ahoy/events_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module Admin
-  class Ahoy::EventsController < Admin::ApplicationController
-    def scoped_resource
-      resource_class.order(time: :desc)
+  module Ahoy
+    class EventsController < Admin::ApplicationController
+      def scoped_resource
+        resource_class.order(time: :desc)
+      end
     end
   end
 end


### PR DESCRIPTION
Ahoy::EventsController < ApplicationController
and Admin::Ahoy::EventsController < Admin::ApplicationController

But writing module Admin
then class Ahoy::EventsController confused it.