### PR TITLE
Use a small threshold to consider a comment edited

### DIFF
--- a/app/javascript/conversation/LeadComment.jsx
+++ b/app/javascript/conversation/LeadComment.jsx
@@ -102,7 +102,7 @@ function LeadComment ({
       </Row>
       <blockquote>
         <StyledComment markdown={leadComment.content} />
-        {leadComment.timestamp !== leadComment.updatedAt && (
+        {leadComment.edited && (
           <Edited>
             <FormattedMessage
               id="comments.comment.edited"

--- a/app/javascript/conversation/Response.jsx
+++ b/app/javascript/conversation/Response.jsx
@@ -60,7 +60,7 @@ function Response ({
         <>
           <SpeechBubble>
             <StyledComment markdown={comment.content} />
-            {comment.timestamp !== comment.updatedAt && (
+            {comment.edited && (
               <Edited>
                 <FormattedMessage
                   id="comments.comment.edited"

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -186,6 +186,7 @@ export type Comment = {
   }[],
   commentThreadId: number,
   content: string,
+  edited: boolean,
   id: string,
   reader: {
     id: string,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -26,6 +26,10 @@ class Comment < ApplicationRecord
   after_create_commit { CommentThreadBroadcastJob.perform_later comment_thread }
   after_create_commit :send_notifications_of_reply
 
+  def edited?
+    updated_at - created_at > 1.minute
+  end
+
   private
 
   # Send a notification over ActionCable to participants in the thread other

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -4,6 +4,7 @@
 class CommentSerializer < ApplicationSerializer
   attributes :id, :content, :timestamp, :updated_at, :comment_thread_id
   attribute :attachments
+  attribute :edited?, key: :edited
 
   belongs_to :reader, serializer: Readers::IdenticonSerializer
 

--- a/spec/features/editing_a_comment_spec.rb
+++ b/spec/features/editing_a_comment_spec.rb
@@ -24,13 +24,15 @@ feature 'Editing a comment' do
         expect(page).to have_content comment.content
       end
 
+      travel 10.minutes
+
       within '[data-testid="SelectedCommentThread"]' do
         find('blockquote', text: comment.content).hover
         click_button 'Edit comment'
 
-        field = find('.public-DraftEditor-content', text: comment.content).click
-        page.driver.browser.action.
-          send_keys(:backspace, :delete)
+        find('.public-DraftEditor-content', text: comment.content).click
+        page.driver.browser.action
+            .send_keys(:backspace, :delete)
             .send_keys('Hello World!')
             .perform
         click_button 'Save'
@@ -55,7 +57,6 @@ feature 'Editing a comment' do
       create :enrollment, reader: reader, case: kase
       forum = kase.forums.first
       thread = create :comment_thread, forum: forum
-      _lead_comment = create :comment, comment_thread: thread
       comment = create :comment, reader: reader, comment_thread: thread
 
       login_as reader
@@ -70,11 +71,13 @@ feature 'Editing a comment' do
         expect(page).to have_content comment.content
       end
 
+      travel 10.minutes
+
       within '[data-testid="SelectedCommentThread"]' do
         find('blockquote', text: comment.content).hover
         click_button 'Edit comment'
 
-        field = find('.public-DraftEditor-content', text: comment.content).click
+        find('.public-DraftEditor-content', text: comment.content).click
         page.driver.browser.action.
           # Not to match content even if cursor is at beginning/end of input
           send_keys(:backspace, :delete)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,6 +78,7 @@ RSpec.configure do |config|
   config.include Orchard::Integration::TestHelpers::Authentication, type: :feature
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.before(:all, type: :feature) do
     Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
Due to the way that ActiveStorage handles attachment creation, a new
comment created with attachments would be immediately marked edited. Now
we’re only considering a comment edited if its updated_at timestamp is
more than a minute later than its created_at timestamp.