### PR TITLE
Validate that library logos are PNG

### DIFF
--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -13,7 +13,7 @@ class Library < ApplicationRecord
   include Mobility
   extend FriendlyId
 
-  HEX_COLOR = /\A#\h{6}\z/
+  HEX_COLOR = /\A#\h{6}\z/.freeze
 
   attribute :background_color, :text, default: '#000000'
   attribute :foreground_color, :text, default: '#ffffff'
@@ -31,8 +31,7 @@ class Library < ApplicationRecord
             format: { with: HEX_COLOR }, allow_blank: true
   validates :logo, size: { less_than: 2.megabytes,
                            message: 'cannot be larger than 2 MB' },
-                   content_type: { in: %w[image/png image/svg+xml],
-                                   message: 'must be PNG or SVG' }
+                   content_type: { in: %w[image/png], message: 'must be PNG' }
   validates :name, presence: true
 
   scope :ordered, -> { order cases_count: :desc }
@@ -40,6 +39,7 @@ class Library < ApplicationRecord
 
   def self.find(id)
     return SharedCasesLibrary.instance if id.blank?
+
     super(id)
   end
 end

--- a/app/views/libraries/_form.html.haml
+++ b/app/views/libraries/_form.html.haml
@@ -23,14 +23,13 @@
         t 'helpers.attachments.max_size.ruby',
           size: number_to_human_size(2.megabytes)
       }<br />#{
-        t 'helpers.attachments.file_type.ruby',
-        types: %w[SVG PNG].to_sentence
+        t 'helpers.attachments.file_type.ruby', types: %w[PNG].to_sentence
       }".html_safe
 
     = f.form_group :logo, helper_text: logo_helper_text do |f, error_classes|
       = f.file_field :logo, class: %i[pt-fill] + error_classes,
                             direct_upload: true,
-                            accept: 'image/png, image/svg+xml'
+                            accept: 'image/png'
 
     - if policy(Library).create?
       = f.check_box :visible_in_catalog


### PR DESCRIPTION
Inline user-submitted SVGs open us up to XSS vulnerabilities, so in
Rails 5.2.2 ActiveStorage won’t display them.