### PR TITLE
Accept inbound emails to create replies in the forum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '6.0.0.beta3'
 
 # Infrastructure
 gem 'aws-sdk-s3', require: false
+gem 'aws-sdk-sns', '>= 1.9.0', require: false
 gem 'bootsnap', require: false
 gem 'connection_pool'
 gem 'dalli'

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem 'skylight', '>= 4.0.x'
 gem 'table_print'
 
 # Services
+gem 'email_reply_parser'
 gem 'opengraph_parser'
 gem 'ruby-oembed'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.48.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
+    aws-sdk-sns (1.11.0)
+      aws-sdk-core (~> 3, >= 3.48.0)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     axiom-types (0.1.1)
@@ -589,6 +592,7 @@ DEPENDENCIES
   ahoy_matey
   awesome_print
   aws-sdk-s3
+  aws-sdk-sns (>= 1.9.0)
   barnes
   bootsnap
   bullet!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,7 @@ GEM
       activemodel-serializers-xml (>= 1.0)
       activesupport (>= 5.0)
       request_store (>= 1.0)
+    email_reply_parser (0.5.9)
     equalizer (0.0.11)
     errbase (0.1.1)
     erubi (1.8.0)
@@ -606,6 +607,7 @@ DEPENDENCIES
   devise-i18n
   doc_to_dash!
   draper
+  email_reply_parser
   factory_bot_rails
   faker
   flamegraph

--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -2,5 +2,5 @@
 
 # @abstract
 class ApplicationMailbox < ActionMailbox::Base
-  # routing /something/i => :somewhere
+  routing /^reply/i => :replies
 end

--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# @abstract
+class ApplicationMailbox < ActionMailbox::Base
+  # routing /something/i => :somewhere
+end

--- a/app/mailboxes/replies_mailbox.rb
+++ b/app/mailboxes/replies_mailbox.rb
@@ -5,11 +5,13 @@
 class RepliesMailbox < ApplicationMailbox
   # @route [reply+thread-key@mailbox.learngala.com]
   def process
-    Comment.create!(
+    comment = Comment.new(
       reader: reader,
       comment_thread: thread,
       content: clean_content
     )
+
+    comment.save! if Pundit.policy(reader, comment).create?
   end
 
   private

--- a/app/mailboxes/replies_mailbox.rb
+++ b/app/mailboxes/replies_mailbox.rb
@@ -5,7 +5,11 @@
 class RepliesMailbox < ApplicationMailbox
   # @route [reply+thread-key@mailbox.learngala.com]
   def process
-    Comment.create!(reader: reader, comment_thread: thread, content: content)
+    Comment.create!(
+      reader: reader,
+      comment_thread: thread,
+      content: clean_content
+    )
   end
 
   private
@@ -17,6 +21,10 @@ class RepliesMailbox < ApplicationMailbox
 
   def reader
     Reader.find_by! email: mail.from.first
+  end
+
+  def clean_content
+    EmailReplyParser.parse_reply(content)
   end
 
   def content

--- a/app/mailboxes/replies_mailbox.rb
+++ b/app/mailboxes/replies_mailbox.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Users can post comments by replying to notifications they receive about
+# comments others have posted in threads they’re participating in.
+class RepliesMailbox < ApplicationMailbox
+  # @route [reply+thread-key@mailbox.learngala.com]
+  def process
+    Comment.create!(reader: reader, comment_thread: thread, content: content)
+  end
+
+  private
+
+  def thread
+    key = mail.to.first.match(/reply\+(?<key>.+)@/)[:key]
+    CommentThread.find_by! key: key
+  end
+
+  def reader
+    Reader.find_by! email: mail.from.first
+  end
+
+  def content
+    if mail.multipart?
+      mail.text_part
+    else
+      mail.decoded
+    end
+  end
+end

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -11,6 +11,8 @@
 class CommentThread < ApplicationRecord
   default_scope { order(updated_at: :desc) }
 
+  attribute :key, :string, default: -> { SecureRandom.uuid }
+
   belongs_to :card, touch: true, optional: true
   belongs_to :forum, touch: true
   belongs_to :reader

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -24,6 +24,8 @@ class CommentThread < ApplicationRecord
   has_one :case, through: :forum
   has_one :community, through: :forum
 
+  validates :key, presence: true
+
   # The comment threads that are visible to a given reader
   # @return [ActiveRecord::Relation<CommentThread>]
   def self.visible_to_reader(reader)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
+  # Prepare the ingress controller used to receive mail
+  # config.action_mailbox.ingress = :amazon
+
   # Settings specified here will take precedence over those in
   # config/application.rb.
 
@@ -103,6 +106,8 @@ Rails.application.configure do
   else
     config.action_mailer.raise_delivery_errors = false
   end
+
+  config.action_mailbox.ingress = :amazon
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/db/migrate/20190320160900_add_key_to_comment_thread.rb
+++ b/db/migrate/20190320160900_add_key_to_comment_thread.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddKeyToCommentThread < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comment_threads, :key, :string
+
+    reversible do |dir|
+      dir.up do
+        execute 'CREATE EXTENSION IF NOT EXISTS pgcrypto'
+        CommentThread.update_all 'key = gen_random_uuid()'
+      end
+    end
+
+    add_index :comment_threads, :key, unique: true
+  end
+end

--- a/db/migrate/20190320215448_create_action_mailbox_tables.action_mailbox.rb
+++ b/db/migrate/20190320215448_create_action_mailbox_tables.action_mailbox.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_mailbox (originally 20180917164000)
+class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_mailbox_inbound_emails do |t|
+      t.integer :status, default: 0, null: false
+      t.string  :message_id, null: false
+      t.string  :message_checksum, null: false
+
+      t.timestamps
+
+      t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -21,6 +21,13 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 
 
+--
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
 SET search_path = public, pg_catalog;
 
 --
@@ -375,7 +382,8 @@ CREATE TABLE comment_threads (
     card_id integer,
     reader_id integer,
     forum_id integer,
-    comments_count integer
+    comments_count integer,
+    key character varying
 );
 
 
@@ -2142,6 +2150,13 @@ CREATE INDEX index_comment_threads_on_forum_id ON comment_threads USING btree (f
 
 
 --
+-- Name: index_comment_threads_on_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_comment_threads_on_key ON comment_threads USING btree (key);
+
+
+--
 -- Name: index_comment_threads_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3026,6 +3041,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181108181434'),
 ('20190219154939'),
 ('20190222195858'),
-('20190319130136');
+('20190319130136'),
+('20190320160900');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -64,6 +64,39 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
+-- Name: action_mailbox_inbound_emails; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE action_mailbox_inbound_emails (
+    id bigint NOT NULL,
+    status integer DEFAULT 0 NOT NULL,
+    message_id character varying NOT NULL,
+    message_checksum character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: action_mailbox_inbound_emails_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE action_mailbox_inbound_emails_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: action_mailbox_inbound_emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE action_mailbox_inbound_emails_id_seq OWNED BY action_mailbox_inbound_emails.id;
+
+
+--
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1393,6 +1426,13 @@ ALTER SEQUENCE visits_id_seq OWNED BY visits.id;
 
 
 --
+-- Name: action_mailbox_inbound_emails id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY action_mailbox_inbound_emails ALTER COLUMN id SET DEFAULT nextval('action_mailbox_inbound_emails_id_seq'::regclass);
+
+
+--
 -- Name: active_storage_attachments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1669,6 +1709,14 @@ CREATE MATERIALIZED VIEW cases_search_index AS
      LEFT JOIN cards ON ((cards.case_id = cases.id)))
   GROUP BY cases.id
   WITH NO DATA;
+
+
+--
+-- Name: action_mailbox_inbound_emails action_mailbox_inbound_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY action_mailbox_inbound_emails
+    ADD CONSTRAINT action_mailbox_inbound_emails_pkey PRIMARY KEY (id);
 
 
 --
@@ -1965,6 +2013,13 @@ ALTER TABLE ONLY tags
 
 ALTER TABLE ONLY visits
     ADD CONSTRAINT visits_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_action_mailbox_inbound_emails_uniqueness; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_action_mailbox_inbound_emails_uniqueness ON action_mailbox_inbound_emails USING btree (message_id, message_checksum);
 
 
 --
@@ -3042,6 +3097,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190219154939'),
 ('20190222195858'),
 ('20190319130136'),
-('20190320160900');
+('20190320160900'),
+('20190320215448');
 
 

--- a/spec/factories/reply_notifications.rb
+++ b/spec/factories/reply_notifications.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :reply_notification do
+    association :reader
+    association :comment
+
+    after :build do |this|
+      this.notifier = this.comment.reader
+      this.comment_thread = this.comment.comment_thread
+      this.case = this.comment_thread.forum.case
+    end
+  end
+end

--- a/spec/mailboxes/replies_mailbox_spec.rb
+++ b/spec/mailboxes/replies_mailbox_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe RepliesMailbox, type: :mailbox do
     expect(comment.content).to eq 'Yeah I agree.'
   end
 
+  it 'does not post a comment by a reader who’s not allowed' do
+    reader = create :reader
+    thread = create :comment_thread
+
+    receive_response <<~EMAIL, reader: reader, thread: thread
+      Yeah I agree.
+
+      > On Mar 20, 2019, at 12:00, Pearl Zhu Zeng <hello@learngala.com> wrote:
+      >
+      > This is cool.
+    EMAIL
+
+    comment = thread.comments.last
+    expect(comment).not_to be_present
+  end
+
   def receive_response(message, reader:, thread:)
     receive_inbound_email_from_mail(
       to: "reply+#{thread.key}@mailbox.learngala.com",

--- a/spec/mailboxes/replies_mailbox_spec.rb
+++ b/spec/mailboxes/replies_mailbox_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RepliesMailbox, type: :mailbox do
+  it 'creates a new comment from the email contents' do
+    reader = create :reader
+    thread = create :comment_thread
+    reader.enrollments.create case: thread.case
+
+    receive_response 'Yeah I agree.', reader: reader, thread: thread
+
+    comment = thread.comments.last
+    expect(comment).to be_present
+    expect(comment.reader).to eq reader
+    expect(comment.content).to eq 'Yeah I agree.'
+  end
+
+  def receive_response(message, reader:, thread:)
+    receive_inbound_email_from_mail(
+      to: "reply+#{thread.key}@mailbox.learngala.com",
+      from: reader.name_and_email,
+      body: message
+    )
+  end
+end

--- a/spec/mailers/reply_notification_mailer_spec.rb
+++ b/spec/mailers/reply_notification_mailer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReplyNotificationMailer do
+  describe 'notify' do
+    it 'includes reply to header for inbound responses' do
+      thread = create :comment_thread
+      mail = reply_notification_mail thread
+
+      reply_to = "reply+#{thread.key}@mailbox.learngala.com"
+      expect(mail.reply_to).to include(reply_to)
+    end
+  end
+
+  private
+
+  def reply_notification_mail(thread)
+    new_comment = create :comment, comment_thread: thread
+    notification = create :reply_notification, comment: new_comment
+
+    ReplyNotificationMailer.notify notification
+  end
+end

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommentThread, type: :model do
+  context '#key' do
+    it 'is unguessable' do
+      thread = build_stubbed :comment_thread
+
+      expect(thread.key).to match(/\h{8}-\h{4}-\h{4}-\h{4}-\h{12}/)
+    end
+
+    it 'is unique' do
+      thread1 = build_stubbed :comment_thread
+      thread2 = build_stubbed :comment_thread
+
+      expect(thread1.key).not_to eq thread2.key
+    end
+  end
+end

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -4,6 +4,12 @@ require 'rails_helper'
 
 RSpec.describe CommentThread, type: :model do
   context '#key' do
+    it 'validates the presence of key' do
+      thread = build_stubbed :comment_thread, key: nil
+
+      expect(thread).not_to be_valid
+    end
+
     it 'is unguessable' do
       thread = build_stubbed :comment_thread
 


### PR DESCRIPTION
This PR uses the new Rails 6 framework ActionMailbox to allow users to reply directly to comment notification emails to create a response in the comment thread.

We added a Reply-To header to the emails sent by ReplyNotificationMailer#notify: `reply+{{thread.key}}@mailbox.learngala.com`. The thread key corresponds to a random UUID added to the comment_threads table and generated when a CommentThread is initialized.

ActionMailbox routes inbound emails beginning with "reply" to the RepliesMailbox, where we look up the Reader by the From address, and the thread by the key embedded in the To address. The reader is authorized to create the comment based on the CommentPolicy.

To extract the important part of the reply, removing signatures and quoted text, we lean on the gem that GitHub extracted from their own email reply parsing feature, `email_reply_parser`.

Migrations: **YES**