### PR TITLE
Refactor to avoid multiple top-level constants defined in the same file

### DIFF
--- a/app/models/onboarding_script.rb
+++ b/app/models/onboarding_script.rb
@@ -1,74 +1,18 @@
 # frozen_string_literal: true
 
-# Specifies what to do to onboard a user who has not chosen a particular persona
-class OnboardingScript
+# Namespace and factory for configuration objects that define what a onboarding
+# a particular reader needs given their chosen persona
+module OnboardingScript
   def self.for(reader)
     case reader.persona
     when 'learner'
-      LearnerOnboardingScript.new(reader)
+      Learner.new(reader)
     when 'teacher'
-      TeacherOnboardingScript.new(reader)
+      Teacher.new(reader)
     when 'writer'
-      WriterOnboardingScript.new(reader)
+      Writer.new(reader)
     else
-      new(reader)
+      Base.new(reader)
     end
-  end
-
-  def self.all_spotlights
-    return ['test_dummy'] if Rails.env.test?
-
-    []
-  end
-
-  attr_reader :reader
-
-  def initialize(reader)
-    @reader = reader
-  end
-
-  def spotlights
-    self.class.all_spotlights - reader.acknowledged_spotlights
-  end
-end
-
-# Specifies what to do to onboard a reader who wants to learn with cases
-class LearnerOnboardingScript < OnboardingScript
-  def self.all_spotlights
-    super + [
-      'catalog_search',     # search box on the catalog page
-      'catalog_categories', # natural resources header
-      'comment',            # respond button on a card
-      'community_chooser',  # when enrolled, if there’s more than one community
-      'conversation_view'   # over conversation button
-    ]
-  end
-end
-
-# Specifies what to do to onboard a reader who wants to teach with cases
-class TeacherOnboardingScript < OnboardingScript
-  def self.all_spotlights
-    super + [
-      'catalog_search',     # see above
-      'catalog_categories', # see above
-      'caselog',            # over conversation button
-      'deploy',             # toolbar button
-      'invite_learners',    # on the deployments page
-      'add_quiz',           # on the deployments page
-      'deployment_details'  # on the deployments page, over N enrolled
-    ]
-  end
-end
-
-# Specifies what to do to onboard a reader who wants to write their own cases
-class WriterOnboardingScript < OnboardingScript
-  def self.all_spotlights
-    super + [
-      'add_collaborators', # toolbar button
-      'publish',           # over “options” button, for “when you’re finished”
-      'first-caselog',     # see above
-      'add_edgenote',      # editor toolbar button
-      'add_citation'       # editor toolbar button
-    ]
   end
 end

--- a/app/models/onboarding_script/base.rb
+++ b/app/models/onboarding_script/base.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module OnboardingScript
+  # Specifies what to do to onboard a user who has not chosen a persona
+  class Base
+    def self.all_spotlights
+      return ['test_dummy'] if Rails.env.test?
+
+      []
+    end
+
+    attr_reader :reader
+
+    def initialize(reader)
+      @reader = reader
+    end
+
+    def spotlights
+      self.class.all_spotlights - reader.acknowledged_spotlights
+    end
+  end
+end

--- a/app/models/onboarding_script/learner.rb
+++ b/app/models/onboarding_script/learner.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OnboardingScript
+  # Specifies what to do to onboard a reader who wants to learn with cases
+  class Learner < Base
+    def self.all_spotlights
+      super + [
+        'catalog_search',     # search box on the catalog page
+        'catalog_categories', # natural resources header
+        'comment',            # respond button on a card
+        'community_chooser',  # when enrolled, if more than one community
+        'conversation_view'   # over conversation button
+      ]
+    end
+  end
+end

--- a/app/models/onboarding_script/teacher.rb
+++ b/app/models/onboarding_script/teacher.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module OnboardingScript
+  # Specifies what to do to onboard a reader who wants to teach with cases
+  class Teacher < Base
+    def self.all_spotlights
+      super + [
+        'catalog_search',     # see above
+        'catalog_categories', # see above
+        'caselog',            # over conversation button
+        'deploy',             # toolbar button
+        'invite_learners',    # on the deployments page
+        'add_quiz',           # on the deployments page
+        'deployment_details'  # on the deployments page, over N enrolled
+      ]
+    end
+  end
+end

--- a/app/models/onboarding_script/writer.rb
+++ b/app/models/onboarding_script/writer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OnboardingScript
+  # Specifies what to do to onboard a reader who wants to write their own cases
+  class Writer < Base
+    def self.all_spotlights
+      super + [
+        'add_collaborators', # toolbar button
+        'publish',           # over “options” button, for “when you’re finished”
+        'first-caselog',     # see above
+        'add_edgenote',      # editor toolbar button
+        'add_citation'       # editor toolbar button
+      ]
+    end
+  end
+end

--- a/spec/models/onboarding_script_spec.rb
+++ b/spec/models/onboarding_script_spec.rb
@@ -7,19 +7,19 @@ RSpec.describe OnboardingScript do
     it 'returns the right subclass based on the given reader' do
       reader = build :reader, persona: nil
       expect(OnboardingScript.for(reader))
-        .to be_an_instance_of OnboardingScript
+        .to be_an_instance_of OnboardingScript::Base
 
       reader.persona = :learner
       expect(OnboardingScript.for(reader))
-        .to be_a LearnerOnboardingScript
+        .to be_a OnboardingScript::Learner
 
       reader.persona = :teacher
       expect(OnboardingScript.for(reader))
-        .to be_a TeacherOnboardingScript
+        .to be_a OnboardingScript::Teacher
 
       reader.persona = :writer
       expect(OnboardingScript.for(reader))
-        .to be_a WriterOnboardingScript
+        .to be_a OnboardingScript::Writer
     end
   end
 end
@@ -50,9 +50,9 @@ RSpec.shared_examples 'an OnboardingScript' do
 end
 
 [
-  LearnerOnboardingScript,
-  TeacherOnboardingScript,
-  WriterOnboardingScript
+  OnboardingScript::Learner,
+  OnboardingScript::Teacher,
+  OnboardingScript::Writer
 ].each do |klass|
   RSpec.describe klass do
     it_behaves_like 'an OnboardingScript'


### PR DESCRIPTION
Zeitwerk, the new autoloader in Rails 6, requires top-level constants to be
defined in their own files.