### PR TITLE
Change reading_lists primary key to bigint

### DIFF
--- a/app/controllers/reading_lists_controller.rb
+++ b/app/controllers/reading_lists_controller.rb
@@ -58,7 +58,7 @@ class ReadingListsController < ApplicationController
     @reading_list =
       ReadingList
       .includes(reading_list_items: [case: [cover_image_attachment: :blob]])
-      .find(params[:uuid])
+      .find_by_uuid(params[:uuid])
   end
 
   def update_reading_list

--- a/app/models/reading_list.rb
+++ b/app/models/reading_list.rb
@@ -5,6 +5,8 @@
 # @attr title [String]
 # @attr description [String]
 class ReadingList < ApplicationRecord
+  attribute :uuid, :string, default: -> { SecureRandom.uuid }
+
   belongs_to :reader
 
   has_many :reading_list_saves, dependent: :destroy
@@ -20,6 +22,10 @@ class ReadingList < ApplicationRecord
   accepts_nested_attributes_for :reading_list_items, allow_destroy: true
 
   alias items reading_list_items
+
+  def to_param
+    uuid
+  end
 
   def case_slugs
     items.map(&:case).map(&:slug)

--- a/db/migrate/20190422154229_change_reading_list_id_to_bigserial.rb
+++ b/db/migrate/20190422154229_change_reading_list_id_to_bigserial.rb
@@ -1,0 +1,71 @@
+class ChangeReadingListIdToBigserial < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :reading_list_items, :reading_lists
+    remove_index :reading_list_items, column: :reading_list_id, using: :btree
+
+    remove_foreign_key :reading_list_saves, :reading_lists
+    remove_index :reading_list_saves, column: :reading_list_id, using: :btree
+    remove_index :reading_list_saves, column: [:reader_id, :reading_list_id],
+                 unique: true
+
+
+    rename_column :reading_lists, :id, :uuid
+    add_column :reading_lists, :id, :bigserial, null: false
+
+    add_index :reading_lists, :uuid, unique: true
+
+    rename_column :reading_list_items, :reading_list_id, :reading_list_uuid
+    add_column :reading_list_items, :reading_list_id, :bigint
+
+    rename_column :reading_list_saves, :reading_list_id, :reading_list_uuid
+    add_column :reading_list_saves, :reading_list_id, :bigint
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+        UPDATE reading_list_items
+           SET reading_list_id = reading_lists.id
+          FROM reading_lists
+         WHERE reading_list_items.reading_list_uuid = reading_lists.uuid;
+
+        UPDATE reading_list_saves
+           SET reading_list_id = reading_lists.id
+          FROM reading_lists
+         WHERE reading_list_saves.reading_list_uuid = reading_lists.uuid;
+
+        ALTER TABLE reading_lists DROP CONSTRAINT reading_lists_pkey;
+        ALTER TABLE reading_lists
+              ADD CONSTRAINT reading_lists_pkey PRIMARY KEY (id);
+        SQL
+      end
+
+      dir.down do
+        execute <<~SQL
+        UPDATE reading_list_items
+           SET reading_list_uuid = reading_lists.uuid
+          FROM reading_lists
+         WHERE reading_list_items.reading_list_id = reading_lists.id;
+
+        UPDATE reading_list_saves
+           SET reading_list_uuid = reading_lists.uuid
+          FROM reading_lists
+         WHERE reading_list_saves.reading_list_id = reading_lists.id;
+
+        ALTER TABLE reading_lists DROP CONSTRAINT reading_lists_pkey;
+        ALTER TABLE reading_lists
+              ADD CONSTRAINT reading_lists_pkey PRIMARY KEY (uuid);
+        SQL
+      end
+    end
+
+    remove_column :reading_list_items, :reading_list_uuid, :uuid
+    remove_column :reading_list_saves, :reading_list_uuid, :uuid
+
+    add_foreign_key :reading_list_items, :reading_lists
+    add_index :reading_list_items, :reading_list_id, using: :btree
+
+    add_foreign_key :reading_list_saves, :reading_lists
+    add_index :reading_list_saves, :reading_list_id, using: :btree
+    add_index :reading_list_saves, [:reader_id, :reading_list_id], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1172,10 +1172,10 @@ CREATE TABLE reading_list_items (
     id bigint NOT NULL,
     notes text DEFAULT ''::text NOT NULL,
     "position" integer NOT NULL,
-    reading_list_id uuid,
     case_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    reading_list_id bigint
 );
 
 
@@ -1205,9 +1205,9 @@ ALTER SEQUENCE reading_list_items_id_seq OWNED BY reading_list_items.id;
 CREATE TABLE reading_list_saves (
     id bigint NOT NULL,
     reader_id bigint,
-    reading_list_id uuid,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    reading_list_id bigint
 );
 
 
@@ -1235,13 +1235,33 @@ ALTER SEQUENCE reading_list_saves_id_seq OWNED BY reading_list_saves.id;
 --
 
 CREATE TABLE reading_lists (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    uuid uuid DEFAULT gen_random_uuid() NOT NULL,
     title character varying DEFAULT ''::character varying NOT NULL,
     description text DEFAULT ''::text NOT NULL,
     reader_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    id bigint NOT NULL
 );
+
+
+--
+-- Name: reading_lists_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE reading_lists_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: reading_lists_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE reading_lists_id_seq OWNED BY reading_lists.id;
 
 
 --
@@ -1727,6 +1747,13 @@ ALTER TABLE ONLY reading_list_items ALTER COLUMN id SET DEFAULT nextval('reading
 --
 
 ALTER TABLE ONLY reading_list_saves ALTER COLUMN id SET DEFAULT nextval('reading_list_saves_id_seq'::regclass);
+
+
+--
+-- Name: reading_lists id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY reading_lists ALTER COLUMN id SET DEFAULT nextval('reading_lists_id_seq'::regclass);
 
 
 --
@@ -2708,6 +2735,13 @@ CREATE INDEX index_reading_lists_on_reader_id ON reading_lists USING btree (read
 
 
 --
+-- Name: index_reading_lists_on_uuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_reading_lists_on_uuid ON reading_lists USING btree (uuid);
+
+
+--
 -- Name: index_reply_notifications_on_reader_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3301,6 +3335,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190320215448'),
 ('20190402133633'),
 ('20190402133819'),
-('20190405162440');
+('20190405162440'),
+('20190422154229');
 
 


### PR DESCRIPTION
While it was cool to use a uuid type primary key for reading_lists, that
decision made it impossible to use as a polymorphic relation to another
table. Consistency is more important than elegance.