### PR TITLE
Support Edgenote embeds for shinyapps.io

### DIFF
--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -42,5 +42,6 @@ unless naive_oembed_url.blank?
   naive << 'https://*.maps.arcgis.com/apps/webappviewer/*'
   naive << 'https://*.maps.arcgis.com/apps/View/*'
   naive << 'https://plot.ly/~*/*.embed'
+  naive << 'https://*.shinyapps.io/*'
   OEmbed::Providers.register naive
 end


### PR DESCRIPTION
Interactive Shiny apps built with R and hosted on shinyapps.io should be able to be embedded as interactive Edgenotes. While shinyapps.io doesn't implement OEmbed itself, we can add support using our naive OEmbed provider.

---

Hey @waisaed, how's it going? Rebecca forwarded me some threads. Seems like there's some exciting new collaborations getting started :) Hope you're all well and staying in good spirits.
