### PR TITLE
Bugfix for cloned cases not appearing in search

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,7 +15,7 @@ blocks:
           commands:
           - checkout
           - cache restore gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock),gems-$SEMAPHORE_GIT_BRANCH-,gems-master-
-          - sem-version ruby 2.6.1
+          - sem-version ruby 2.6.6
           - sudo apt-get -y install libmagickcore-dev libmagickwand-dev
           - bundle install --deployment -j 4 --path vendor/bundle
           - cache store gems-$SEMAPHORE_GIT_BRANCH-$(checksum Gemfile.lock) vendor/bundle
@@ -41,7 +41,7 @@ blocks:
         commands:
           - checkout
 
-          - sem-version ruby 2.6.1
+          - sem-version ruby 2.6.6
           - sem-version node 12.5.0
           - sem-service start postgres
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,9 @@ GEM
     memoist (0.16.2)
     memory_profiler (0.9.14)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -529,7 +531,7 @@ GEM
       skylight-core (= 4.2.3)
     skylight-core (4.2.3)
       activesupport (>= 4.2.0)
-    spring (2.1.0)
+    spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
@@ -589,6 +591,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   active_model_serializers (= 0.10.10)

--- a/app/cloners/case_cloner.rb
+++ b/app/cloners/case_cloner.rb
@@ -5,6 +5,7 @@ class CaseCloner < Clowne::Cloner
   include_associations :editorships#, :taggings
 
   nullify :published_at
+  nullify :translation_base_id
 
   finalize do |source, record, locale:, slug: SecureRandom.uuid, **|
     record.locale = locale
@@ -29,7 +30,6 @@ class CaseCloner < Clowne::Cloner
       element = case_element.element
       element.class.cloner_class.call(element, kase: record)
     end
-
   end
 end
 

--- a/app/cloners/case_cloner.rb
+++ b/app/cloners/case_cloner.rb
@@ -5,13 +5,13 @@ class CaseCloner < Clowne::Cloner
   include_associations :editorships#, :taggings
 
   nullify :published_at
-  nullify :translation_base_id
 
   finalize do |source, record, locale:, slug: SecureRandom.uuid, **|
     record.locale = locale
     record.slug = slug
     if source.locale == record.locale
       record.title = "COPY: #{record.title}"
+      record.translation_base_id = nil
     else
       record.title = "#{Translation.language_name(locale)}: #{record.title}"
       record.translators = ['—']

--- a/spec/cloners/case_cloner_spec.rb
+++ b/spec/cloners/case_cloner_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe CaseCloner, type: :cloner do
 
     expect(first_card(clone).paragraphs).to eq first_card(kase).paragraphs
     expect(first_card(clone).case).to eq clone
+    expect(clone.translation_base_id).to eq(clone.id)
   end
 
   private

--- a/spec/cloners/case_cloner_spec.rb
+++ b/spec/cloners/case_cloner_spec.rb
@@ -48,7 +48,18 @@ RSpec.describe CaseCloner, type: :cloner do
 
     expect(first_card(clone).paragraphs).to eq first_card(kase).paragraphs
     expect(first_card(clone).case).to eq clone
+  end
+
+  it "clears translaton base id when not translating" do
+    kase = create :case_with_edgenotes, locale: :en
+    clone = described_class.call kase, locale: :en
     expect(clone.translation_base_id).to eq(clone.id)
+  end
+
+  it "sets translation base id when translating" do
+    kase = create :case_with_edgenotes, locale: :en
+    clone = described_class.call kase, locale: :fr
+    expect(clone.translation_base_id).to eq(kase.id)
   end
 
   private

--- a/spec/controllers/translations_controller_spec.rb
+++ b/spec/controllers/translations_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TranslationsController do
+  let(:reader) { create :reader }
+  let(:kase) { create :case }
+
+  before do
+    sign_in reader
+  end
+
+  describe 'POST #create' do
+    it 'translates the case' do
+      kase.editors << reader
+      expect {
+      post :create, params: { case_slug: kase.slug, case_locale: 'es' }
+      }.to change{ kase.translations.count }.from(0).to(1)
+    end
+  end
+end

--- a/spec/features/following_a_magic_link_spec.rb
+++ b/spec/features/following_a_magic_link_spec.rb
@@ -61,6 +61,7 @@ feature 'Following a magic link' do
     saved_reader = Reader.find_by_email reader.email
     visit reader_confirmation_path confirmation_token: saved_reader.confirmation_token
 
+    click_on 'Sign in'
     fill_in 'Email', with: reader.email
     fill_in 'Password', with: reader.password
     click_on 'Sign in'


### PR DESCRIPTION
Easy fix - have the cloner nullify the translation_base_id on the case so that its own normal lifecycle event will populate it.  Confirmed by unit test.