### PR TITLE
Add development container configs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/devcontainers/base:bullseye
+
+# Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
+# The value is a comma-separated list of allowed domains
+# requires Rails 7, otherwise config in config/environments/development.rb
+ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.preview.app.github.dev,.app.github.dev"
+
+# the ruby build seems to expect mkdir in /usr/bin. It's not clear what the
+# root cause is for this but this symlink works around it for now - 2 March 2023
+RUN ln -s /bin/mkdir /usr/bin/mkdir
+
+# [Optional] Uncomment this section to install additional OS packages.
+# shared-mime-info for an image gem
+# python2 for old node packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        iputils-ping \
+        libpq-dev postgresql-client \
+        shared-mime-info \
+        python2 \
+        cmake
+
+ENV EDITOR="code --wait"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby-rails-postgres
+{
+	"name": "Gala",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"rebornix.Ruby",
+				"mutantdino.resourcemonitor"
+			]
+		}
+	},
+
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "lts/erbium"
+		},
+		"ghcr.io/devcontainers/features/ruby:1": {
+			"version": "2.6.6"
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [3000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash .devcontainer/setup"
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [3000],
+	"forwardPorts": [3000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "bash .devcontainer/setup"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,7 @@ services:
 
     environment:
       REDIS_URL: "redis://redis:6379"
+      USE_SELENIUM_SIDECAR: "true"
 
     volumes:
       # the current working directory from the Mac
@@ -16,8 +17,15 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    network_mode: service:postgres
-
+  selenium:
+    # selenium doesn't have universal containers, so if you are on Intel,
+    # change this to selenium/standalone-chrome:latest
+    image: seleniarm/standalone-chromium:latest
+    shm_size: '2g'
+    environment:
+      SE_NODE_MAX_SESSIONS: 4
+      SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
+    network_mode: service:app
 
   redis:
     image: redis:6.2.5
@@ -31,6 +39,8 @@ services:
       POSTGRES_PASSWORD: wibble
     volumes:
       - "pgsql-data:/var/lib/postgresql/data"
+
+    network_mode: service:app
 
 volumes:
   pgsql-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.7'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    environment:
+      REDIS_URL: "redis://redis:6379"
+
+    volumes:
+      # the current working directory from the Mac
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    network_mode: service:postgres
+
+
+  redis:
+    image: redis:6.2.5
+    volumes:
+      - "redis-data:/data"
+
+  postgres:
+    image: postgres:10.18-bullseye
+    environment:
+      POSRTGRES_USER: postgres
+      POSTGRES_PASSWORD: wibble
+    volumes:
+      - "pgsql-data:/var/lib/postgresql/data"
+
+volumes:
+  pgsql-data:
+  redis-data:

--- a/.devcontainer/setup
+++ b/.devcontainer/setup
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# create vscode user
+createuser -h localhost -U postgres --superuser vscode

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Gala is a platform for the collaborative study of media-rich teaching cases.
 
 ## Install and Setup
 
-[Visual Studio Code users read below](#visual-studio-code)
+[A Visual Studio Code dev container option is available](#visual-studio-code-dev-container)
 
 You will need to have the following prerequisites installed locally in order to run Gala:
 
@@ -39,7 +39,7 @@ Create and seed your development and test databases:
     rails db:setup
     rails db:test:prepare
 
-## Visual Studio Code
+## Visual Studio Code Dev Container
 
 If you have `docker` running - I use [colima](https://github.com/abiosoft/colima) on macOS - you can quickly bring up the project in a dev container.
 

--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,8 @@ Gala is a platform for the collaborative study of media-rich teaching cases.
 
 ## Install and Setup
 
+[Visual Studio Code users read below](#visual-studio-code)
+
 You will need to have the following prerequisites installed locally in order to run Gala:
 
  - Ruby 2.6.6
@@ -36,6 +38,16 @@ Create and seed your development and test databases:
 
     rails db:setup
     rails db:test:prepare
+
+## Visual Studio Code
+
+If you have `docker` running - I use [colima](https://github.com/abiosoft/colima) on macOS - you can quickly bring up the project in a dev container.
+
+  - Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
+  - Open this project in Visual Studio Code
+  - Click the "Reopen in Container" button that appears, or use the command "Dev Containers: Reopen in Container"
+  - Once built, start a new terminal in VSCode, and use `bin/setup` to install dependencies, setup the database.
+
 
 ## Cron jobs
 

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies
-  # system('bin/yarn')
+  system('bin/yarn')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: localhost
 
 development:
   <<: *default

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest app/javascript"
   },
   "engines": {
-    "node": "12.5",
+    "node": "12.x",
     "yarn": "1.x"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds an initial configuration for bringing up `gala` in a VSCode devcontainer, versus installing PostgreSQL, Redis, Node, and Ruby on the developer's device.

The only file outside of the `.devcontainer` that needed to be adjusted was `database.yml` where I added the `host: localhost`. This is because the containers only talk to each other over TCP and not a UNIX socket.

I additionally changed `package.json` to allow for any 12.x version of Node.