### PR TITLE
Fix: layout tweaks

### DIFF
--- a/app/javascript/edgenotes/Edgenote.jsx
+++ b/app/javascript/edgenotes/Edgenote.jsx
@@ -343,7 +343,7 @@ export default connect(
 const Container = styled.figure.attrs({ className: 'edge pt-dark' })`
   position: relative;
   margin: 0 0 1em;
-
+  overflow-wrap: anywhere;
   @media screen and (max-width: 1300px) {
     margin-top: 1em;
   }

--- a/app/javascript/utility/Lock.jsx
+++ b/app/javascript/utility/Lock.jsx
@@ -127,7 +127,7 @@ const LockDetails = styled.div.attrs({ className: 'pt-card pt-elevation-4' })`
   left: 50%;
   opacity: 0;
   position: absolute;
-  top: 50%;
+  top: 20%;
   transform: translate(-50%, -50%);
   transition: 0.2s ease-out opacity 0.1s;
   width: 300px;


### PR DESCRIPTION
1. wrap URLs in edgenotes to avoid long URLs breaking the layout
2. move the edit lock info box up so it is visible without scrolling down on overview page and long cards