### PR TITLE
Use destroy instead of unlock in CleanupLocksJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ equivalent to run `rake indices:refresh` as frequently as makes sense.
 
 To send a weekly report of usage data, run `rake emails:send_weekly_report` once
 per week.
+
+Run `rake locks:enqueue_cleanup` hourly to delete locks older than 8 hours.

--- a/app/jobs/cleanup_locks_job.rb
+++ b/app/jobs/cleanup_locks_job.rb
@@ -25,12 +25,9 @@ class CleanupLocksJob < ApplicationJob
   end
 
   def unlock_single_resource(lock)
-    resource = lock.lockable
-    resource.unlock
+    lock.destroy!
     BroadcastEdit.to(lock, type: :destroy, session_id: nil)
   rescue StandardError => e
-    Rails.logger.error <<~ERROR_MESSAGE
-      Failed to unlock Resource: #{resource.inspect} with Error: #{e.message}
-    ERROR_MESSAGE
+    Rails.logger.error "destroy Lock##{lock.id} failed: #{e.message}"
   end
 end

--- a/app/jobs/cleanup_locks_job.rb
+++ b/app/jobs/cleanup_locks_job.rb
@@ -25,7 +25,7 @@ class CleanupLocksJob < ApplicationJob
   end
 
   def unlock_single_resource(lock)
-    lock.destroy!
+    lock.destroy
     BroadcastEdit.to(lock, type: :destroy, session_id: nil)
   rescue StandardError => e
     Rails.logger.error "destroy Lock##{lock.id} failed: #{e.message}"


### PR DESCRIPTION
Fixes issue where locks don't get destroyed by the  CleanupLocksJob.

Using `Lockable#unlock` fails if associated model is invalid.
Using `Lock#destroy` skirts that validation