### PR TITLE
add interactive oEmbed support for Matterport for edgenotes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,7 +499,7 @@ GEM
       parser (>= 3.1.1.0)
     rubocop-faker (1.0.0)
       rubocop (>= 0.74)
-    ruby-oembed (0.12.0)
+    ruby-oembed (0.16.1)
     ruby-progressbar (1.11.0)
     ruby-vips (2.0.17)
       ffi (~> 1.9)

--- a/app/models/link_expansion/embed.rb
+++ b/app/models/link_expansion/embed.rb
@@ -4,7 +4,7 @@ class LinkExpansion
   # OEmbed resource
   class Embed
     def self.for(url, with_visibility:)
-      new(url, with_visibility)
+      instance = new(url, with_visibility)
     rescue OEmbed::NotFound, OEmbed::UnknownResponse
       {}
     end

--- a/app/models/link_expansion/embed.rb
+++ b/app/models/link_expansion/embed.rb
@@ -4,7 +4,7 @@ class LinkExpansion
   # OEmbed resource
   class Embed
     def self.for(url, with_visibility:)
-      instance = new(url, with_visibility)
+      new(url, with_visibility)
     rescue OEmbed::NotFound, OEmbed::UnknownResponse
       {}
     end

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -46,6 +46,10 @@ crowdsignal = OEmbed::Provider.new 'https://api.crowdsignal.com/oembed'
 crowdsignal << 'https://*.survey.fm/*'
 OEmbed::Providers.register crowdsignal
 
+matterport = OEmbed::Provider.new 'https://my.matterport.com/api/v1/models/oembed/'
+matterport << 'https://my.matterport.com/show/*'
+OEmbed::Providers.register matterport
+
 naive_oembed_url = Rails.application.credentials.dig :naive_oembed_url
 unless naive_oembed_url.blank?
   naive = OEmbed::Provider.new naive_oembed_url

--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -47,7 +47,7 @@ crowdsignal << 'https://*.survey.fm/*'
 OEmbed::Providers.register crowdsignal
 
 matterport = OEmbed::Provider.new 'https://my.matterport.com/api/v1/models/oembed/'
-matterport << 'https://my.matterport.com/show/*'
+matterport << 'https://*.matterport.com/show/*'
 OEmbed::Providers.register matterport
 
 naive_oembed_url = Rails.application.credentials.dig :naive_oembed_url


### PR DESCRIPTION
Matterport 3D models can now be embedded into an edgenote and be interactive!

Example to test with: https://my.matterport.com/show/?m=BhA7ZV94LY4&play=1&wh=0

I added extra query parameters to this link:
- play=1 makes the tour start automatically on load
- wh=0 traps the mouse scrolling event when focused inside the model
- [link](https://support.matterport.com/s/article/URL-Parameters?language=en_US) to query parameter options

I found the Matterport oEmbed URL from [this OSS project.](https://github.com/iamcal/oembed/blob/068c7b94f77a23635ff1e4b82d466fe50c535f93/providers/matterport.yml#L4)

Here's an example of the oEmbed endpoint working in action:
https://my.matterport.com/api/v1/models/oembed/?url=https%3A//my.matterport.com/show/%3Fm%3DBhA7ZV94LY4