### PR TITLE
Fix i18n issue for OAuth readers with unsupported locales

### DIFF
--- a/app/models/case/pdf.rb
+++ b/app/models/case/pdf.rb
@@ -62,7 +62,9 @@ class Case
     def options
       {
         root_url: root_url.to_s,
-        protocol: root_url.scheme
+        protocol: root_url.scheme,
+        footer_left: @case_study.license_config['name'],
+        footer_font_size: 8,
       }
     end
   end

--- a/app/models/case/pdf.rb
+++ b/app/models/case/pdf.rb
@@ -64,7 +64,7 @@ class Case
         root_url: root_url.to_s,
         protocol: root_url.scheme,
         footer_left: @case_study.license_config['name'],
-        footer_font_size: 8,
+        footer_font_size: 8
       }
     end
   end

--- a/app/models/reader.rb
+++ b/app/models/reader.rb
@@ -177,6 +177,11 @@ class Reader < ApplicationRecord
 
   # Overridden from Devise for I18n
   def send_devise_notification(notification, *args)
+    locale = if I18n.available_locales.include?(self.locale.to_sym)
+      self.locale
+    else
+      I18n.default_locale
+    end
     I18n.with_locale(locale) { super notification, *args }
   end
 

--- a/app/models/reader.rb
+++ b/app/models/reader.rb
@@ -178,10 +178,10 @@ class Reader < ApplicationRecord
   # Overridden from Devise for I18n
   def send_devise_notification(notification, *args)
     locale = if I18n.available_locales.include?(self.locale.to_sym)
-      self.locale
-    else
-      I18n.default_locale
-    end
+               self.locale
+             else
+               I18n.default_locale
+             end
     I18n.with_locale(locale) { super notification, *args }
   end
 


### PR DESCRIPTION
Gala was throwing a 500 error when sending a confirmation email using an unsupported locale.

Solution was to fallback to `I18n.default_locale` for the email.