### PR TITLE
validate Edgenote#website_url

### DIFF
--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -48,6 +48,8 @@ class Edgenote < ApplicationRecord
                     content_type: { in: %w[image/png image/jpeg],
                                     message: 'must be JPEG or PNG' }
 
+  validate :validate_website_url
+
   before_create :ensure_slug_set
 
   def self.policy_class
@@ -78,5 +80,14 @@ class Edgenote < ApplicationRecord
 
   def ensure_slug_set
     self.slug ||= SecureRandom.uuid
+  end
+
+  def validate_website_url
+    return if website_url.blank?
+
+    uri = URI.parse(website_url)
+    errors.add(:website_url, 'must be a valid URL') unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  rescue URI::InvalidURIError
+    errors.add(:website_url, 'must be a valid URL')
   end
 end

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -86,7 +86,7 @@ class Edgenote < ApplicationRecord
     return if website_url.blank?
 
     uri = URI.parse(website_url)
-    if !(uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS))
+    unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
       errors.add(:website_url, 'must be a valid URL')
     end
   rescue URI::InvalidURIError

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -86,7 +86,9 @@ class Edgenote < ApplicationRecord
     return if website_url.blank?
 
     uri = URI.parse(website_url)
-    errors.add(:website_url, 'must be a valid URL') unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+    if !(uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS))
+      errors.add(:website_url, 'must be a valid URL')
+    end
   rescue URI::InvalidURIError
     errors.add(:website_url, 'must be a valid URL')
   end


### PR DESCRIPTION
This PR adds validation to the `website_url` attribute on the `Edgenote` model

### example

![Screenshot 2024-03-06 at 2 11 46 PM](https://github.com/galahq/gala/assets/8855672/4c55b9cd-0b91-44fe-952b-0652b03b13f3)

### references

- https://stackoverflow.com/questions/7167895/rails-whats-a-good-way-to-validate-links-urls
