### PR TITLE
Fix: content editor regressions

### DIFF
--- a/app/javascript/Case.jsx
+++ b/app/javascript/Case.jsx
@@ -132,9 +132,11 @@ class Case extends React.Component<{
   render () {
     const { kicker, basename, needsPretest, hasQuiz, editing } = this.props
     const mathJaxOptions = {
-      menuOptions: {
-        settings: {
-          zoom: 'Click',
+      options: {
+        menuOptions: {
+          settings: {
+            zoom: 'Click',
+          },
         },
       },
     }

--- a/app/javascript/card/CardContents.jsx
+++ b/app/javascript/card/CardContents.jsx
@@ -129,12 +129,12 @@ class CardContents extends React.Component<Props, State> {
       selectedCommentThread,
     })
 
-    function keyBindingFnWithOverrides (e: SyntheticKeyboardEvent<*>) {
+    function keyBindingFnWithOverrides (e: SyntheticKeyboardEvent<*>): ?string {
       if (theseCommentThreadsOpen && acceptingSelection && e.key === 'Enter') {
         addCommentThread()
         return
       }
-      keyBindingFn(e)
+      return keyBindingFn(e)
     }
 
     return (


### PR DESCRIPTION
This PR fixes the regressions introduced by the most recent deployment causing wonky content editor behaviors when backspacing until a card is empty.

The keyboard navigation for better comment thread accessibility is still retained.

