### PR TITLE
fix jsonb_path_to_tsvector reference

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -33,7 +33,7 @@ CREATE FUNCTION public.jsonb_path_to_tsvector(jsondata jsonb, path_elems text[],
   BEGIN
     SELECT INTO tsv
       coalesce(
-        tsvector_agg(to_tsvector(data #>> path_elems)),
+        public.tsvector_agg(to_tsvector(data #>> path_elems)),
         to_tsvector('')
       )
     FROM jsonb_array_elements(jsondata) AS data;


### PR DESCRIPTION
Responding to this ticket https://help.heroku.com/tickets/1397515, which is in reference to the staging app specifically but which may impact the app in general.

>For context, PostgreSQL tooling such as pg_dump and pg_restore, which are used for logical backups, Heroku PGBackups, as well as these version upgrades, run with a limited search_patch that only includes pg_catalog. Because of this, PostgreSQL isn't able to find the tsvector_agg aggregate. Please note that this is impacting our upgrades, but would also impact your ability to create and restore backups from this database in general.