### PR TITLE
Validate react_router_location params on CasesController#show

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p $NVM_DIR \
     && yarn install --check-files
 
 # install gems
-RUN echo "gem: --no-document" /etc/gemrc \
+RUN echo "gem: --no-document" > /etc/gemrc \
     && gem update --system 3.3.22 \
     && gem install bundler:2.4.19 \
     && bundle install --jobs 20 --retry 2 \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Gala is free to use at www.learngala.com and we encourage you to join the commun
 
 1. `rbenv install 2.7.6`
 2. `rbenv shell 2.7.6`
-3. `gem install bundler`
+3. `gem install bundler -v 2.4.19`
 4. `bundle install`
 
 #### Using nodenv

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -22,6 +22,9 @@ class CasesController < ApplicationController
   ].freeze
 
   before_action :authenticate_reader!, except: %i[index show]
+  before_action :validate_react_router_location,
+                only: %i[show],
+                if: -> { params[:react_router_location].present? }
   before_action :set_case, only: %i[show edit update destroy]
   before_action -> { verify_lock_on @case }, only: %i[update destroy]
 
@@ -98,6 +101,15 @@ class CasesController < ApplicationController
   end
 
   private
+
+  # Validates the case path.
+  #
+  # Example:
+  # * Valid URL: /cases/valid-case/1
+  # * Invalid URL: /cases/valid-case/1/3/2/11/6/4/3/2/13/15
+  def validate_react_router_location
+    redirect_to '/404' if params[:react_router_location].split('/').size > 1
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_case

--- a/app/javascript/catalog/shared.jsx
+++ b/app/javascript/catalog/shared.jsx
@@ -78,7 +78,6 @@ export const Element = ({
   wide
 }: ElementProps) => {
   const ElementContainer = href == null ? CaseRow : CaseLinkRow
-  console.log(wide)
   return (
     <ElementContainer href={href} className={className}>
       {images ? <ElementImages srcs={images} /> : <ElementImage src={image} wide={wide} />}

--- a/app/javascript/draft/RevealableEntity.jsx
+++ b/app/javascript/draft/RevealableEntity.jsx
@@ -39,8 +39,6 @@ function RevealableComponent (props) {
   if (!editInProgress) {
     conditionalProps.tabIndex = 0
   }
-console.log(children[0].props.text)
-console.log(children)
 
   return (
     // eslint-disable-next-line

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,8 +91,6 @@ Rails.application.routes.draw do
     get 'confirm_deletion', to: 'cases/deletions#new'
     post 'confirm_deletion', to: 'cases/deletions#create'
 
-    # get 'copy', to: 'cases#copy'
-
     resources :edgenotes, only: %i[create]
 
     resources :editorships, only: %i[new create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,9 +122,9 @@ Rails.application.routes.draw do
   end
 
   scope 'cases' do
-    get ':case_slug/*react_router_location',
+    get ':case_slug(/:react_router_location)',
         to: 'cases#show', format: false,
-        react_router_location: REACT_ROUTER_LOCATION_REGEX
+        constraints: { react_router_location: REACT_ROUTER_LOCATION_REGEX }
   end
 
   namespace 'catalog' do

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe CasesController do
+RSpec.describe CasesController, type: :controller do
   let(:reader) { create :reader }
 
   before do
@@ -16,11 +16,41 @@ RSpec.describe CasesController do
       expect(reader.my_cases.count).to eq 1
     end
 
-    it 'enrolls a the user in the case after it is created' do
+    it 'enrolls the user in the case after it is created' do
       post :create, params: { case: attributes_for(:case) }
 
       reader.enrollments.reload
       expect(reader.enrollments.count).to eq 1
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns 200 with a valid case overview' do
+      case_instance = create(:case, slug: 'valid-case', published: true)
+      get :show, params: { case_slug: case_instance.slug }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 200 with a valid case page' do
+      case_instance = create(:case, slug: 'valid-case', published: true)
+      get :show, params: { case_slug: case_instance.slug,
+                           react_router_location: '1' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'redirects to 404 with an invalid case page' do
+      case_instance = create(:case, slug: 'valid-case', published: true)
+      get :show, params: { case_slug: case_instance.slug,
+                           react_router_location: '1/3/2/11/6/4/3/2/13/15' }
+      expect(response).to redirect_to('/404')
+    end
+
+    it 'returns a 200 response with a valid case with locale' do
+      case_instance = create(:case, slug: 'valid-case', published: true)
+      get :show, params: { locale: 'es', case_slug: case_instance.slug,
+                           react_router_location: '1' }
+      expect(response).to have_http_status(:ok)
+      expect(I18n.locale).to eq :es
     end
   end
 end


### PR DESCRIPTION
Add validation logic to `react_router_location` params on the `CasesController#show` route so crawlers are redirected to a 404 page.

So that a request like this:
```
GET /cases/a3224235-cdc0-44fc-a98b-46735dfef6c9/11/15/3/5/14/7/4
```

Results in a 404 redirect.

Also included in this PR:
- typo in Dockerfile
- remove unnecessary console log lines