### PR TITLE
Fix revealable regressions

### DIFF
--- a/app/assets/stylesheets/Narrative.sass
+++ b/app/assets/stylesheets/Narrative.sass
@@ -170,6 +170,14 @@
 
   &--editing
     cursor: text
+    
+    .revealable-entity__content
+      color: rgba(1, 24, 45, 0.7)
+      background: transparent
+      
+      &[aria-hidden="true"]
+        background: transparent
+        text-decoration: none
 
 .sr-only
   position: absolute

--- a/app/javascript/draft/RevealableEntity.jsx
+++ b/app/javascript/draft/RevealableEntity.jsx
@@ -20,30 +20,40 @@ const RevealableComponent = memo(({ editInProgress, children }) => {
   }, [editInProgress])
 
   const handleClick = e => {
-    e.preventDefault()
-    if (!editInProgress) {
-      setIsRevealed(!isRevealed)
+    if (editInProgress) {
+      return
     }
+    
+    e.preventDefault()
+    setIsRevealed(!isRevealed)
   }
 
   const handleKeyDown = e => {
+    if (editInProgress) {
+      return
+    }
+
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       handleClick(e)
     }
   }
 
+  const interactiveProps = editInProgress ? {} : {
+    role: "button",
+    onClick: handleClick,
+    onKeyDown: handleKeyDown,
+    tabIndex: 0
+  }
+
   return (
     <div 
-      role="button"
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      className={`revealable-entity ${isRevealed ? 'revealable-entity--revealed' : ''}`}
+      {...interactiveProps}
+      className={`revealable-entity ${isRevealed ? 'revealable-entity--revealed' : ''} ${editInProgress ? 'revealable-entity--editing' : ''}`}
       aria-expanded={isRevealed}
-      tabIndex={editInProgress ? -1 : 0}
     >
       {/* Hidden text for screen readers when content is not revealed */}
-      {!isRevealed && (
+      {!isRevealed && !editInProgress && (
         <span className="sr-only">
           This text is hidden, press Enter or Space to reveal
         </span>
@@ -51,9 +61,9 @@ const RevealableComponent = memo(({ editInProgress, children }) => {
 
       <span 
         className="revealable-entity__content"
-        aria-hidden={!isRevealed}
+        aria-hidden={!isRevealed && !editInProgress}
       >
-        {!isRevealed && (
+        {!isRevealed && !editInProgress && (
           <Icon
             icon="caret-down"
             className="revealable-entity__icon"


### PR DESCRIPTION
https://github.com/galahq/gala/commit/2526cb0d50906ad0f765f0cf30634352eedc0c20 introduced a regression where there was no feedback when clicking on a revealable in edit mode, making it difficult to know how to revert revealable text to plain text.

The update allows authors to edit revealable text directly (by turning off `role: 'button'` for revealable text in edit mode).

