### PR TITLE
Change fonts account

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,7 +27,7 @@ blocks:
             
             # Install system dependencies
             - sudo apt-get update
-            - sudo apt-get install -y libmagickcore-dev libmagickwand-dev libffi-dev libvips libssl-dev postgresql-common
+            - DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libmagickcore-dev libmagickwand-dev libffi-dev libvips libssl-dev postgresql-common
 
             # Bundle install with caching
             - BUNDLE_JOBS=4

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,8 +26,9 @@ blocks:
             - gem install bundler:2.4.19 --no-document
             
             # Install system dependencies
+            - echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
             - sudo apt-get update
-            - DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libmagickcore-dev libmagickwand-dev libffi-dev libvips libssl-dev postgresql-common
+            - sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" libmagickcore-dev libmagickwand-dev libffi-dev libvips libssl-dev postgresql-common
 
             # Bundle install with caching
             - BUNDLE_JOBS=4

--- a/app/views/application/_fonts.html.erb
+++ b/app/views/application/_fonts.html.erb
@@ -1,4 +1,4 @@
-<script src="https://use.typekit.net/jvg2ega.js"></script>
+<script src="https://use.typekit.net/adn1xoi.js"></script>
 <script>try{Typekit.load({ async: true });}catch(e){}</script>
 
 <%# We don’t want the Japanese font to override the Chinese fonts, in order


### PR DESCRIPTION
- Changes the Typekit account for fonts to one that can be shared by multiple users.
- Tweak semephore.yml to fix issue with hanging build by giving default response to prompts
- Also removed two fonts (Adelle, Fira Mono) from the Adobe Fonts package that were not being used—this is a change in Adobe CC's config not this codebase, just noting here in case anything breaks...