### PR TITLE
Improve math entity UI

### DIFF
--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -88,18 +88,26 @@ function MathComponent (props) {
       )
 
       if (entityRange) {
+        // Clear any existing selection first
+        window.getSelection().removeAllRanges()
+
         const selection = new SelectionState({
           anchorKey: blockKey,
           anchorOffset: entityRange.start,
-          focusKey: blockKey,
-          focusOffset: entityRange.end
+          focusKey: blockKey, 
+          focusOffset: entityRange.end,
+          hasFocus: true,
+          isBackward: false
         })
 
-        applySelection(cardId, selection)
+        // Ensure we have a valid selection before applying
+        if (selection.getHasFocus()) {
+          applySelection(cardId, selection)
+        }
       }
 
     } catch (err) {
-      console.error('Error selecting math entity:', err)
+      console.error('Error selecting math entity:', err) 
     } finally {
       setIsSelecting(false)
     }

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -35,6 +35,7 @@ function MathComponent (props) {
   const [error, setError] = useState(null)
   const mathRef = useRef(null)
   const [isSelecting, setIsSelecting] = useState(false)
+  const texRef = useRef(null)
 
   if (error) {
     return null
@@ -97,16 +98,37 @@ function MathComponent (props) {
     }
   }
 
+  function handleKeyDown(event) {
+    if (editInProgress) return
+    
+    // Handle Enter or Space key
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      // Trigger MathJax zoom programmatically
+      const mjxContainer = mathRef.current?.querySelector('mjx-container')
+      if (mjxContainer) {
+        mjxContainer.dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window
+        }))
+      }
+    }
+  }
+
   // To select the MATH entity, click right before or after the equation.
   return (
     <MathWrapper 
       ref={mathRef}
       editing={editInProgress} 
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
       tabIndex={0}
+      role="button"
     >
       <CursorTarget editing={editInProgress}>
         <Tex2SVG
+          ref={texRef}
           latex={decoratedText}
           display="inline"
           style={{}}

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -174,11 +174,13 @@ const MathEntity = connect(
 export default MathEntity
 const MathWrapper = styled.button`
   border: none;
-  background: none;
-  padding: 0;
+  background-color: #e5e4dc;
+  padding: 8px;
+  border-radius: 4px;
   margin: 0;
   overflow-x: auto;
   max-width: 656px;
+  min-height: 62px;
   position: relative;
   display: inline-block;
   

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -39,7 +39,15 @@ const MathJaxWrapper = React.forwardRef(function MathJaxWrapper(props, ref) {
 })
 
 function MathComponent (props) {
-  const { decoratedText, offsetKey, contentState, entityKey, applySelection, editInProgress, cardId } = props
+  const { 
+    decoratedText, 
+    offsetKey, 
+    contentState, 
+    entityKey, 
+    applySelection, 
+    editInProgress, 
+    cardId
+  } = props
 
   const [error, setError] = useState(null)
   const mathRef = useRef(null)
@@ -78,7 +86,6 @@ function MathComponent (props) {
       const blockKey = offsetKey.split('-')[0]
       const block = contentState.getBlockForKey(blockKey)
       
-      // Create a promise that resolves with the selection
       const selectionPromise = new Promise(resolve => {
         block.findEntityRanges(character => {
           const e = character.getEntity()
@@ -94,14 +101,11 @@ function MathComponent (props) {
         })
       })
 
-      // Wait for the selection to be created and then apply it
       const selection = await selectionPromise
       await applySelection(cardId, selection)
 
     } catch (err) {
-      if (!err.message?.includes('409')) {
-        console.error('Error selecting math entity:', err)
-      }
+      console.error('Error selecting math entity:', err)
     } finally {
       setIsSelecting(false)
     }

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -88,26 +88,34 @@ function MathComponent (props) {
       )
 
       if (entityRange) {
-        // Clear any existing selection first
-        window.getSelection().removeAllRanges()
-
-        const selection = new SelectionState({
-          anchorKey: blockKey,
+        // Create and verify selection before applying
+        const selection = SelectionState.createEmpty(blockKey).merge({
           anchorOffset: entityRange.start,
-          focusKey: blockKey, 
           focusOffset: entityRange.end,
           hasFocus: true,
           isBackward: false
         })
 
-        // Ensure we have a valid selection before applying
-        if (selection.getHasFocus()) {
+        // Only apply if we have a valid selection
+        if (selection.getAnchorKey() === blockKey && 
+            selection.getFocusKey() === blockKey) {
+          // Create a new range for the DOM selection
+          const range = document.createRange()
+          const element = mathRef.current
+          
+          if (element) {
+            range.selectNodeContents(element)
+            const domSelection = window.getSelection()
+            domSelection.removeAllRanges()
+            domSelection.addRange(range)
+          }
+          
           applySelection(cardId, selection)
         }
       }
 
     } catch (err) {
-      console.error('Error selecting math entity:', err) 
+      console.error('Error selecting math entity:', err)
     } finally {
       setIsSelecting(false)
     }

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -16,10 +16,15 @@ function mapStateToProps (
   { contentState, entityKey }
 ) {
   const { cardId } = contentState.getEntity(entityKey).getData()
+  const card = state.cardsById[cardId]
+  const lockKey = `Card/${cardId}`
   return {
     cardId,
     editInProgress: state.edit.inProgress,
-    editorState: state.cardsById[cardId]?.editorState || EditorState.createEmpty(),
+    // Check if we have a valid lock
+    hasValidLock: state.edit.inProgress && 
+      state.locks[lockKey]?.reader?.param === `${state.caseData.reader?.id || ''}`,
+    editorState: card?.editorState || EditorState.createEmpty(),
   }
 }
 
@@ -45,7 +50,8 @@ function MathComponent (props) {
     contentState, 
     entityKey, 
     applySelection, 
-    editInProgress, 
+    editInProgress,
+    hasValidLock, 
     cardId
   } = props
 
@@ -73,7 +79,8 @@ function MathComponent (props) {
    * https://draftjs.org/docs/advanced-topics-block-components/
    */
   async function handleClick (event) {
-    if (!editInProgress || isSelecting) {
+    // Only proceed if we have a valid lock and are in edit mode
+    if (!hasValidLock || !editInProgress || isSelecting) {
       return
     }
 

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -29,6 +29,15 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
+// Create a wrapper component that handles the ref forwarding
+const MathJaxWrapper = React.forwardRef(function MathJaxWrapper(props, ref) {
+  return (
+    <div ref={ref}>
+      <Tex2SVG {...props} />
+    </div>
+  )
+})
+
 function MathComponent (props) {
   const { decoratedText, offsetKey, contentState, entityKey, applySelection, editInProgress, cardId } = props
 
@@ -127,7 +136,7 @@ function MathComponent (props) {
       role="button"
     >
       <CursorTarget editing={editInProgress}>
-        <Tex2SVG
+        <MathJaxWrapper
           ref={texRef}
           latex={decoratedText}
           display="inline"
@@ -135,7 +144,6 @@ function MathComponent (props) {
           onSuccess={() => setError(null)}
           onError={setError}
           onZoomClose={handleZoomClose}
-          // Disable MathJax menu and zoom when editing
           options={{
             enableMenu: !editInProgress,
             settings: {

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -33,16 +33,31 @@ function MathComponent (props) {
   const { decoratedText, offsetKey, contentState, entityKey, applySelection, editInProgress, cardId } = props
 
   const [error, setError] = useState(null)
+  const mathRef = React.useRef(null)
+
   if (error) {
     return null
   }
 
   /**
-  * Dispatches the target selection when the user clicks on the MATH entity.
-  * Problem is the MATH entity is an SVG instead of text, it's not recommend.
-  * For more info on the problem see:
-  * https://draftjs.org/docs/advanced-topics-block-components/
-  */
+   * Handles zoom window close by ensuring focus is properly managed
+   */
+  const handleZoomClose = React.useCallback((event) => {
+    // Prevent the default focus behavior
+    event.preventDefault()
+    
+    // If we have a ref to our math container, focus it instead
+    if (mathRef.current) {
+      mathRef.current.focus()
+    }
+  }, [])
+
+  /**
+   * Dispatches the target selection when the user clicks on the MATH entity.
+   * Problem is the MATH entity is an SVG instead of text, it's not recommended.
+   * For more info on the problem see:
+   * https://draftjs.org/docs/advanced-topics-block-components/
+   */
   function handleClick () {
     if (!editInProgress) {
       return
@@ -66,14 +81,20 @@ function MathComponent (props) {
 
   // To select the MATH entity, click right before or after the equation.
   return (
-    <MathWrapper editing={editInProgress} onClick={handleClick}>
+    <MathWrapper 
+      ref={mathRef}
+      editing={editInProgress} 
+      onClick={handleClick}
+      tabIndex={0} // Make the wrapper focusable
+    >
       <CursorTarget>
         <Tex2SVG
           latex={decoratedText}
           display="inline"
-          style={""}
+          style={{}}
           onSuccess={() => setError(null)}
           onError={setError}
+          onZoomClose={handleZoomClose} // Add handler for zoom close
         />
       </CursorTarget>
     </MathWrapper>
@@ -88,27 +109,40 @@ const MathEntity = connect(
 
 export default MathEntity
 const MathWrapper = styled.button`
-  border: solid 1px #c0bca9;
-  border-radius: 3px;
-  padding: 8px;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
   overflow-x: auto;
   max-width: 656px;
+  
+  appearance: none;
+  -webkit-appearance: none;
+  
+  vertical-align: middle;
+  
+  font-size: 0.7em;
+  line-height: inherit;
+  
   @media (max-width: 1440px) {
     max-width: 500px;
   }
   @media (max-width: 800px) {
     max-width: 200px;
   }
+  
   ${({ editing }) => editing && `
     &:hover {
       cursor: text;
-      }`}
+    }`}
 
   &>button {
-    background-color: red;
+    background: none;
   }
 `
 
 const CursorTarget = styled.div`
- cursor: zoom-in;
+  cursor: zoom-in;
+  display: inline-block;
+  vertical-align: middle;
 `

--- a/app/javascript/draft/MathEntity.jsx
+++ b/app/javascript/draft/MathEntity.jsx
@@ -13,7 +13,7 @@ import styled from 'styled-components'
 
 function mapStateToProps (
   state: State,
-  { decoratedText, offsetKey, contentState, entityKey }
+  { contentState, entityKey }
 ) {
   const { cardId } = contentState.getEntity(entityKey).getData()
   return {
@@ -139,7 +139,6 @@ function MathComponent (props) {
       tabIndex={0}
       role="button"
     >
-      <CursorTarget editing={editInProgress}>
         <MathJaxWrapper
           ref={texRef}
           latex={decoratedText}
@@ -155,7 +154,6 @@ function MathComponent (props) {
             }
           }}
         />
-      </CursorTarget>
     </MathWrapper>
   )
 }
@@ -210,12 +208,4 @@ const MathWrapper = styled.button`
     z-index: 0;
     pointer-events: ${props => props.editing ? 'none' : 'auto'};
   }
-`
-
-const CursorTarget = styled.div`
-  cursor: ${props => props.editing ? 'text' : 'zoom-in'};
-  display: inline-block;
-  vertical-align: middle;
-  position: relative;
-  z-index: 1;
 `


### PR DESCRIPTION
Makes visual and accessibility improvements to the Math Entity in the card toolbar:

- match text styles, use minimal appearance
- allow zooming into equations with the enter or space keys
- select the entity and provide visual feedback when you click anywhere on the equation in edit mode, so that it can be toggled using the toolbar buttons

These changes leave intact an error that that is already present in production where clicking into another card and then back to the math entity throws an issue related to the locks`locks.json 409 (Conflict)`. This also occurs when selecting a math entity and dragging its card. We should ensure this isn't creating an issue with the locks. Because these issues are already present in prod I am going ahead with the changes.
