### PR TITLE
(WIP) fix default quizzes for deployment groups

### DIFF
--- a/app/controllers/admin/editorships_controller.rb
+++ b/app/controllers/admin/editorships_controller.rb
@@ -2,5 +2,8 @@
 
 module Admin
   class EditorshipsController < Admin::ApplicationController
+    def disabled_actions
+      []
+    end
   end
 end

--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -116,7 +116,7 @@ class DeploymentsController < ApplicationController
   def customized_deployment_params
     params.require(:deployment).permit(
       :answers_needed, :quiz_id,
-      custom_questions: [:id, :content, :correct_answer, options: []]
+      custom_questions: [:id, :content, :correct_answer, { options: [] }]
     )
           .to_h
           .symbolize_keys

--- a/app/javascript/quiz/Quiz.jsx
+++ b/app/javascript/quiz/Quiz.jsx
@@ -33,7 +33,10 @@ type QuizProps = {
   answers: QuizState,
   isInstructor: boolean,
 }
+
 type QuizState = { [questionId: string]: string }
+
+// this is what is prompting the pretest
 type QuizDelegateProps = {
   canSubmit: boolean,
   onChange: (questionId: string, e: SyntheticInputEvent<*>) => void,
@@ -56,8 +59,10 @@ export function providesQuiz<P> (
     state = { submitting: false, quizState: {}}
 
     _canSubmit = () => {
+      // this is what enables or disables the submission button
       const { submissionNeeded, isInstructor, questions } = this.props
       const { submitting, quizState } = this.state
+      console.log({ submissionNeeded, isInstructor, questions, submitting, quizState })
       if (submitting) return false
       if (!submissionNeeded) return false
       if (isInstructor) return false

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -54,18 +54,24 @@ class Deployment < ApplicationRecord
     answers_needed >= 2
   end
 
+  def hide_pretest?(reader)
+    (!quiz || reader.enrollment_for_case(self.case).instructor?) &&
+      Rails.env.production?
+  end
+
   def reader_needs_pretest?(reader)
-    return false unless quiz
-    return false if reader.enrollment_for_case(self.case).instructor?
+    return false if hide_pretest?(reader)
+
     answers_needed - quiz.number_of_responses_from(reader) >= 2
   end
 
   def posttest_assigned?
-    answers_needed >= 1
+    answers_needed.positive? && quiz.present?
   end
 
   def reader_needs_posttest?(reader)
     return false unless quiz
+
     answers_needed - quiz.number_of_responses_from(reader) >= 1
   end
 end

--- a/app/services/customize_deployment_service.rb
+++ b/app/services/customize_deployment_service.rb
@@ -35,15 +35,20 @@ class CustomizeDeploymentService
   end
 
   def should_use_existing_quiz(quiz, with_customizations)
-    return false unless quiz # Can’t use existing if there isn’t one
+    return false unless quiz # Can't use existing if there isn't one
     return true if @author_identifier.author.quiz? quiz # Can mutate their own
+
     with_customizations.empty? # Copy on write (only copy if needed)
   end
 
   def create_quiz_from_template(template_id)
-    Quiz.create! case: @deployment.case,
-                 template_id: template_id,
-                 customized: true
+    template_quiz = Quiz.create! case: @deployment.case,
+                                 template_id: template_id,
+                                 customized: true
+    template_quiz.reload
+    puts "Template Quiz ID: #{template_quiz.id}"
+    puts "Template Quiz Case ID: #{template_quiz.case_id}"
+    template_quiz
   end
 
   def customize_quiz(custom_questions)

--- a/app/views/deployments/show.html.haml
+++ b/app/views/deployments/show.html.haml
@@ -23,6 +23,8 @@
   %main.md-detail
     %h2.admin__title= t '.quiz_details'
 
+    -# TODO check why this isn't isn't true after adding a new deployment that
+    -# has default quiz assigned
     - if !deployment.posttest_assigned?
       %span.pt-tag.pt-minimal.pt-large= t '.no_quiz_assigned'
       = link_to edit_deployment_path(deployment),


### PR DESCRIPTION
Not ready for review yet.

It's working locally on this branch, but had to change the original logic to test it more easily. I.e. I'm allowing instructors to view the quizzes on their deployments to make testing easier. _This logic can be removed easily if we want it to work like it did previously._

The main change is that instructors can see the pre- and post-quizzes when viewing their deployed case. This helps with testing.

Note: Learners cannot open any page of a case until the pre-quiz is submitted if the deployment had that configuration set.

Key files to keep in mind when fixing this:
- CustomizeDeploymentService
- QuizUpdater
- Deployment model
- all the FE files in `app/javascript/quiz`

Will sync up with @waisaed before making this draft live.