### PR TITLE
Fix quiz feature

### DIFF
--- a/app/javascript/quiz/customizer/index.jsx
+++ b/app/javascript/quiz/customizer/index.jsx
@@ -63,7 +63,7 @@ function QuizCustomizer ({ customQuestions, onChange }: Props) {
 
       <FlushButton
         elementRef={addQuestionButtonRef}
-        alone={customQuestions.length === 0}
+        alone={customQuestions.length === 0 ? "true" : "false"}
         icon="add"
         onClick={handleAppendQuestion}
       >
@@ -76,6 +76,6 @@ function QuizCustomizer ({ customQuestions, onChange }: Props) {
 export default QuizCustomizer
 
 const FlushButton = styled(Button)`
-  margin-top: ${({ alone }: { alone: boolean }) => (alone ? '0.5em' : '0')};
+  margin-top: ${({ alone }: { alone: string }) => (alone === "true" ? '0.5em' : '0')};
   margin-left: -17px;
 `

--- a/app/javascript/redux/actions/suggestedQuizzes.js
+++ b/app/javascript/redux/actions/suggestedQuizzes.js
@@ -43,15 +43,24 @@ function setSuggestedQuizzes (
   return { type: 'SET_SUGGESTED_QUIZZES', quizzes }
 }
 
-export function createSuggestedQuiz (): ThunkAction {
+export function createSuggestedQuiz (quiz: SuggestedQuiz): ThunkAction {
   return (dispatch: Dispatch, getState: GetState) => {
     const { slug } = getState().caseData
-    return Orchard.graft(`cases/${slug}/quizzes`, {}).then(
-      (quiz: SuggestedQuiz) => {
-        dispatch(addSuggestedQuiz(quiz.param, quiz))
-        return quiz.param
+    return Orchard.graft(`cases/${slug}/quizzes`, { ...quiz, id: null, param: null }).then(
+      (newQuiz: SuggestedQuiz) => {
+        console.log("newQuiz", newQuiz)
+        // dispatch(addSuggestedQuiz(newQuiz.param, newQuiz))
+        dispatch(fetchSuggestedQuizzes())
+        return newQuiz.param
       }
     )
+  }
+}
+
+export function newSuggestedQuiz (): ThunkAction {
+  return (dispatch: Dispatch, getState: GetState) => {
+    dispatch(addSuggestedQuiz("new", { param: "new", questions: [], title: "New Quiz" }))
+    return Promise.resolve("new")
   }
 }
 
@@ -60,7 +69,7 @@ export type AddSuggestedQuizAction = {
   param: string,
   data: SuggestedQuiz,
 }
-function addSuggestedQuiz (
+export function addSuggestedQuiz (
   param: string,
   data: SuggestedQuiz
 ): AddSuggestedQuizAction {

--- a/app/javascript/redux/actions/suggestedQuizzes.js
+++ b/app/javascript/redux/actions/suggestedQuizzes.js
@@ -48,9 +48,14 @@ export function createSuggestedQuiz (quiz: SuggestedQuiz): ThunkAction {
     const { slug } = getState().caseData
     return Orchard.graft(`cases/${slug}/quizzes`, { ...quiz, id: null, param: null }).then(
       (newQuiz: SuggestedQuiz) => {
-        console.log("newQuiz", newQuiz)
-        // dispatch(addSuggestedQuiz(newQuiz.param, newQuiz))
         dispatch(fetchSuggestedQuizzes())
+        dispatch(
+          displayToast({
+            intent: Intent.SUCCESS,
+            icon: 'tick-circle',
+            message: 'Quiz successfully created',
+          })
+        )
         return newQuiz.param
       }
     )

--- a/app/javascript/redux/reducers/suggestedQuizzes.js
+++ b/app/javascript/redux/reducers/suggestedQuizzes.js
@@ -32,6 +32,10 @@ export default function suggestedQuizzes (
       }, {})
 
     case 'ADD_SUGGESTED_QUIZ':
+      return {
+        ...state,
+        [action.param]: action.data,
+      }
     case 'UPDATE_SUGGESTED_QUIZ':
       return {
         ...state,

--- a/app/javascript/suggested_quizzes/QuizDetails.jsx
+++ b/app/javascript/suggested_quizzes/QuizDetails.jsx
@@ -14,6 +14,7 @@ import QuizCustomizer from 'quiz/customizer'
 import { validatedQuestions } from 'suggested_quizzes/helpers'
 
 import {
+  createSuggestedQuiz,
   updateSuggestedQuiz,
   displayErrorToast,
   setUnsaved,
@@ -39,6 +40,7 @@ type Props = OwnProps & {
   history: RouterHistory,
   quiz: SuggestedQuiz,
   updateSuggestedQuiz: typeof updateSuggestedQuiz,
+  createSuggestedQuiz: typeof createSuggestedQuiz,
 }
 function QuizDetails ({
   displayErrorToast,
@@ -47,6 +49,7 @@ function QuizDetails ({
   intl,
   quiz,
   updateSuggestedQuiz,
+  createSuggestedQuiz,
 }: Props) {
   const [draftQuiz, setDraftQuiz] = React.useState(quiz)
   const { questions, title } = draftQuiz
@@ -73,7 +76,12 @@ function QuizDetails ({
         intl.formatMessage({ id: 'cases.edit.suggestedQuizzes.error' })
       )
     } else {
-      updateSuggestedQuiz(id, draftQuiz)
+      console.log('handleSave', { id, draftQuiz })
+      if (id === "new") {
+        createSuggestedQuiz(draftQuiz)
+      } else {
+        updateSuggestedQuiz(id, draftQuiz)
+      }
       unblock()
       history.replace('/suggested_quizzes/')
     }
@@ -113,7 +121,7 @@ function QuizDetails ({
 export default injectIntl(
   connect(
     mapStateToProps,
-    { updateSuggestedQuiz, displayErrorToast }
+    { updateSuggestedQuiz, createSuggestedQuiz, displayErrorToast }
   )(QuizDetails)
 )
 

--- a/app/javascript/suggested_quizzes/QuizDetails.jsx
+++ b/app/javascript/suggested_quizzes/QuizDetails.jsx
@@ -76,7 +76,6 @@ function QuizDetails ({
         intl.formatMessage({ id: 'cases.edit.suggestedQuizzes.error' })
       )
     } else {
-      console.log('handleSave', { id, draftQuiz })
       if (id === "new") {
         createSuggestedQuiz(draftQuiz)
       } else {

--- a/app/javascript/suggested_quizzes/index.jsx
+++ b/app/javascript/suggested_quizzes/index.jsx
@@ -14,14 +14,14 @@ import AllQuizzes from 'suggested_quizzes/AllQuizzes'
 import QuizDetails from 'suggested_quizzes/QuizDetails'
 import CaseOverview from 'overview/CaseOverview'
 
-import { createSuggestedQuiz } from 'redux/actions'
+import { newSuggestedQuiz } from 'redux/actions'
 
 import type { ContextRouter } from 'react-router-dom'
 
 type Props = ContextRouter & {
-  createSuggestedQuiz: typeof createSuggestedQuiz,
+  newSuggestedQuiz: typeof newSuggestedQuiz,
 }
-function SuggestedQuizzes ({ createSuggestedQuiz, history, match }: Props) {
+function SuggestedQuizzes ({ newSuggestedQuiz, history, match }: Props) {
   return (
     <Container>
       <Route component={CaseOverview} />
@@ -49,11 +49,11 @@ function SuggestedQuizzes ({ createSuggestedQuiz, history, match }: Props) {
             path="/suggested_quizzes"
             render={({ history }) => (
               <AllQuizzes
-                onCreateQuiz={() =>
-                  createSuggestedQuiz().then(id =>
-                    history.push(`/suggested_quizzes/${id}`)
-                  )
-                }
+                onCreateQuiz={() => {
+                  newSuggestedQuiz().then(quizId => {
+                    history.push(`/suggested_quizzes/${quizId}`)
+                  })
+                }}
               />
             )}
           />
@@ -65,7 +65,7 @@ function SuggestedQuizzes ({ createSuggestedQuiz, history, match }: Props) {
 
 export default connect(
   null,
-  { createSuggestedQuiz }
+  { newSuggestedQuiz }
 )(SuggestedQuizzes)
 
 const Container = styled.div`

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -32,10 +32,8 @@ class Quiz < ApplicationRecord
 
   scope :suggested, -> { where author_id: nil, lti_uid: nil }
 
-  validate :must_have_at_least_one_question
-
   # A relation of quizzes that the reader, in the context of her active group,
-  # hasn’t answered enough times. Whether “enough” is 1 or 2 depends on the
+  # hasn’t answered enough times. Whether ”enough” is 1 or 2 depends on the
   # instructor’s choice, per {Deployment}.
   # @return [ActiveRecord::Relation<Quiz>]
   def self.requiring_response_from(reader)

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -97,8 +97,6 @@ class Quiz < ApplicationRecord
            .values.min || 0
   end
 
-  private
-
   def must_have_at_least_one_question
     return if custom_questions.any? || (template.present? && template.questions.any?)
 

--- a/app/services/customize_deployment_service.rb
+++ b/app/services/customize_deployment_service.rb
@@ -14,8 +14,7 @@ class CustomizeDeploymentService
       if quiz_id.present?
         @deployment.quiz = get_quiz quiz_id, with_customizations: custom_questions
         customize_quiz custom_questions unless custom_questions.empty?
-      elsif answers_needed > 0
-        # Create a new quiz when no template is provided but answers are needed
+      elsif answers_needed.positive?
         @deployment.quiz = Quiz.create!(
           case: @deployment.case,
           customized: true,
@@ -25,6 +24,8 @@ class CustomizeDeploymentService
       end
       @deployment.tap(&:save!)
     end
+  rescue ActiveRecord::RecordInvalid => e
+    e.record
   end
 
   private


### PR DESCRIPTION
# Quiz Behavior Spec (from #755)

This spec outlines decisions about quiz creation, editing, and instructor experience.

## Context

- Instructors deploy quizzes to assess learner understanding.
- Case authors create suggested quizzes before publishing.
- Instructors can assign suggested quizzes or create custom ones (with optional base questions + additions).

## Spec

- [ ] **Disallow empty quizzes**
  - Require a title and at least one question
  - Enforce in both UI and model

- [ ] **Distinguish suggested vs. custom quizzes in editor**
  - Visually differentiate instructor-created and system-generated (empty) quizzes

- [ ] **Restrict deletion of suggested quizzes**
  - No global or per-deployment deletion
  - Use visual indicators instead

- [ ] **Copy on edit for suggested quizzes**
  - Modifying a suggested quiz creates a private, editable copy

- [ ] **Improve instructor quiz preview**
  - Preferred: allow instructors to interact like learners
  - Fallback: turn off submit and add “preview” note

## Status

Item 1 addresses a system fix and is included in this pull request. The remaining items represent a working specification based on the discussions in #755.