### PR TITLE
Add a language filter to catalog search

### DIFF
--- a/app/controllers/catalog/languages_controller.rb
+++ b/app/controllers/catalog/languages_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Catalog
+  # Index the languages that should be displayed in the catalog
+  class LanguagesController < ApplicationController
+    # @route [GET] `/catalog/languages`
+    def index
+      # Get languages that actually have cases
+      languages_with_cases = Case.published
+                                 .joins(:translation_base)
+                                 .reorder(nil)  # Remove any existing ordering
+                                 .distinct
+                                 .pluck(:locale)
+                                 .compact
+                                 .sort
+
+      # Map locale codes to language names using the Translation module
+      @languages = languages_with_cases.map do |locale|
+        {
+          code: locale,
+          name: Translation::AVAILABLE_LANGUAGES[locale.to_sym] || locale.humanize
+        }
+      end
+
+      render json: @languages
+    end
+  end
+end

--- a/app/javascript/catalog/search_results/LanguageChooser.jsx
+++ b/app/javascript/catalog/search_results/LanguageChooser.jsx
@@ -1,0 +1,102 @@
+/**
+ * MultiSelect dropdown to present language suggestions.
+ *
+ * @providesModule LanguageChooser
+ * @flow
+ */
+
+import * as React from 'react'
+import * as R from 'ramda'
+import styled from 'styled-components'
+import { injectIntl } from 'react-intl'
+import { MenuItem } from '@blueprintjs/core'
+import { MultiSelect } from '@blueprintjs/select'
+import { Orchard } from 'shared/orchard'
+
+function LanguageChooser({ intl, onChange, languages }) {
+  const [items, setItems] = React.useState([])
+  const [loading, setLoading] = React.useState(false)
+
+  const isLanguageSelected = React.useCallback((language) => 
+    languages.map(l => l.code).includes(language.code), [languages]
+  )
+
+  const renderMenuItem = React.useCallback((
+    language,
+    { handleClick, modifiers: { active, disabled, matchesPredicate }}
+  ) => {
+    if (!matchesPredicate) return null
+    const selected = isLanguageSelected(language)
+    return (
+      <MenuItem
+        key={language.code}
+        active={active}
+        disabled={disabled}
+        icon={selected ? 'tick' : 'blank'}
+        text={language.name}
+        onClick={e => selected || handleClick(e)}
+      />
+    )
+  }, [isLanguageSelected])
+
+  const loadLanguages = React.useCallback(async () => {
+    setLoading(true)
+    try {
+      const items = await Orchard.harvest('catalog/languages')
+      setItems(items)
+    } catch (error) {
+      console.error('Failed to load languages:', error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    loadLanguages()
+  }, [loadLanguages])
+
+  const handleRemove = React.useCallback(({ props: { language }}) => {
+    onChange(R.without([language], languages))
+  }, [onChange, languages])
+
+  const handleItemSelect = React.useCallback((language) => {
+    onChange([...languages, language])
+  }, [onChange, languages])
+
+  return (
+    <div className="pt-dark">
+      <MultiSelect
+        items={items}
+        selectedItems={languages}
+        itemRenderer={renderMenuItem}
+        noResults={
+          <MenuItem
+            disabled={true}
+            text={intl.formatMessage({
+              id: loading ? 'helpers.loading' : 'catalog.languages.noResults',
+            })}
+          />
+        }
+        tagRenderer={language => (
+          <LanguageTag language={language}>{language.name}</LanguageTag>
+        )}
+        popoverProps={{
+          className: 'language-chooser__popover',
+          minimal: true,
+        }}
+        //
+        tagInputProps={{
+          leftIcon: 'translate',
+          onRemove: handleRemove,
+        }}
+        onItemSelect={handleItemSelect}
+      />
+    </div>
+  )
+}
+
+export default injectIntl(LanguageChooser)
+
+const LanguageTag = styled.span`
+  text-transform: capitalize;
+`

--- a/app/javascript/catalog/search_results/SearchForm.jsx
+++ b/app/javascript/catalog/search_results/SearchForm.jsx
@@ -14,11 +14,14 @@ import { injectIntl, FormattedMessage } from 'react-intl'
 import { Button, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
 import { CatalogSection, SectionTitle } from 'catalog/shared'
 import KeywordsChooser from 'overview/keywords/KeywordsChooser'
+import LanguageChooser from './LanguageChooser'
 
 import type { IntlShape } from 'react-intl'
 import type { ContextRouter } from 'react-router-dom'
 import type { Query } from 'catalog/search_results/getQueryParams'
 import type { Tag } from 'redux/state'
+
+type Language = { code: string, name: string }
 
 type Props = {| ...ContextRouter, params: Query, intl: IntlShape |}
 function SearchForm ({ history, intl, params }: Props) {
@@ -30,12 +33,17 @@ function SearchForm ({ history, intl, params }: Props) {
     createTagObjects(params.tags)
   )
 
+  const [languageObjects, setLanguageObjects] = React.useState(
+    createLanguageObjects(params.languages)
+  )
+
   function handleSubmit (e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault()
     const searchPath = getSearchPath({
       q: query,
       libraries: params.libraries,
       tags: tagObjects.map(tag => tag.name),
+      languages: languageObjects.map(lang => lang.code),
     })
     history.push(searchPath)
   }
@@ -63,6 +71,10 @@ function SearchForm ({ history, intl, params }: Props) {
           <KeywordsChooser tags={tagObjects} onChange={setTagObjects} />
         </FormGroup>
 
+        <FormGroup label={<FormattedMessage id="catalog.languages.Languages" />}>
+          <LanguageChooser languages={languageObjects} onChange={setLanguageObjects} />
+        </FormGroup>
+
         <SubmitButton>
           <FormattedMessage id="search.search" />
         </SubmitButton>
@@ -75,6 +87,10 @@ export default injectIntl(withRouter(SearchForm))
 
 function createTagObjects (names: ?(string[])): Tag[] {
   return names ? names.map(name => ({ name, displayName: name })) : []
+}
+
+function createLanguageObjects (codes: ?(string[])): Language[] {
+  return codes ? codes.map(code => ({ code, name: code })) : []
 }
 
 export function getSearchPath (params: Object): string {

--- a/app/javascript/catalog/search_results/getQueryParams.js
+++ b/app/javascript/catalog/search_results/getQueryParams.js
@@ -24,7 +24,7 @@ function coerceIntoArrayValues (params: {
 }
 
 function getQueryFromPathname (pathname: string): { [string]: string[] } {
-  return ['libraries', 'tags'].reduce((params, key) => {
+  return ['libraries', 'tags', 'languages'].reduce((params, key) => {
     const match = pathname.match(RegExp(`${key}/([0-9a-z%+-]+)`))
     if (!match) return params
     params[key] = [match[1]]

--- a/app/services/find_cases.rb
+++ b/app/services/find_cases.rb
@@ -2,7 +2,7 @@
 
 # Find {Case}s matching search parameters
 class FindCases
-  # @param params [{libraries?: string[], tags?: string[], q?: string}]
+  # @param params [{libraries?: string[], tags?: string[], languages?: string[], q?: string}]
   # @return [ActiveRecord::Relation<Case>]
   def self.by(params, locale:)
     new(params, locale: locale).call
@@ -18,6 +18,7 @@ class FindCases
         .with_locale_or_fallback(@locale)
         .merge(maybe_filter_by_library)
         .merge(maybe_filter_by_tags)
+        .merge(maybe_filter_by_languages)
         .merge(maybe_search_by_full_text)
   end
 
@@ -45,6 +46,12 @@ class FindCases
 
     Case.joins(taggings: [:tag])
         .where(taggings: { tags: { name: @params[:tags] } })
+  end
+
+  def maybe_filter_by_languages
+    return Case.all if @params[:languages].blank?
+
+    Case.where(locale: @params[:languages])
   end
 
   def maybe_search_by_full_text

--- a/app/services/find_cases.rb
+++ b/app/services/find_cases.rb
@@ -14,12 +14,18 @@ class FindCases
   end
 
   def call
-    Case.ordered
-        .with_locale_or_fallback(@locale)
-        .merge(maybe_filter_by_library)
-        .merge(maybe_filter_by_tags)
-        .merge(maybe_filter_by_languages)
-        .merge(maybe_search_by_full_text)
+    base_scope = Case.ordered
+                     .merge(maybe_filter_by_library)
+                     .merge(maybe_filter_by_tags)
+                     .merge(maybe_filter_by_languages)
+                     .merge(maybe_search_by_full_text)
+    
+    # Only apply locale fallback if no specific language filter is applied
+    if @params[:languages].present?
+      base_scope
+    else
+      base_scope.with_locale_or_fallback(@locale)
+    end
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,6 +325,9 @@ en:
       Publish your case and share it as widely as you like. Institutions can create 
       libraries with multiple cases.
     keywords: Keywords
+    languages:
+      Languages: Languages
+      noResults: No languages found
     wikidata:
       link_wikidata: Wikidata Links
       find_item: Find a Wikidata item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Rails.application.routes.draw do
     end
 
     resources :libraries, only: %i[index]
+    resources :languages, only: %i[index]
 
     get '*react_router_location',
         action: :home, format: false,


### PR DESCRIPTION
Adds the ability to filter cases by language from the catalog search page.
The dropdown list should be populated based on the languages represented by cases in the catalog.

Normally, a translation of a case will replace the original in search if the user's locale is set to that language. When filtering by a specific language we ignore that logic and only show the version in the given language.