### PR TITLE
Rotate Mapbox token

### DIFF
--- a/app/javascript/map_view/index.jsx
+++ b/app/javascript/map_view/index.jsx
@@ -36,7 +36,7 @@ type State = {
   openPin: string,
 }
 
-const token = "pk.eyJ1IjoiY2JvdGhuZXIiLCJhIjoiY2oyOWZ2bGNuMDI1MDMybzVoc2Ntb3kwYiJ9.QA8nck8XiK5dxF6R7M_HAg";
+const token = "pk.eyJ1IjoiY2JvdGhuZXIiLCJhIjoiY21nNTNlOWM2MDBnazJqcHI3NGtlNjJ5diJ9.NSLz94UIqonNQKbD030jow";
 
 
 class MapViewController extends React.Component<Props, State> {


### PR DESCRIPTION
The token that was being used here had no URL restrictions and is exposed to the client, meaning it is possible to grab it from the Gala site and use it on another project. A sudden spike in usage this month led to my account having a non-zero bill (still only like $2) for the first time. I'm worried that an LLM may have grabbed the token and suggested it for reuse in someone else's project, so I'm swapping it here for a token with URL restrictions that limiting its use to `https://www.learngala.com`. Then I will rotate my public token